### PR TITLE
build(renovate): ignore `node`, `npm` and `pnpm` when checking for updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,10 @@
     {
       "matchUpdateTypes": ["digest", "minor", "patch", "pin"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["node", "npm", "pnpm"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
…dates