### PR TITLE
revert: deactivate “Sort import on save” option

### DIFF
--- a/.idea/biome.xml
+++ b/.idea/biome.xml
@@ -3,6 +3,5 @@
   <component name="BiomeSettings">
     <option name="applySafeFixesOnSave" value="true" />
     <option name="formatOnSave" value="true" />
-    <option name="sortImportOnSave" value="true" />
   </component>
 </project>


### PR DESCRIPTION
Biome’s plugin 1.6.0 for JetBrains IDEs is buggy.

See https://github.com/biomejs/biome-intellij/issues/143

Ref: aec31cb