### PR TITLE
feat(commit-analyser): get release type

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,7 +1,6 @@
 import type { CliOptions, Context, ContextBase } from "./cli.types.js";
 
-import { parseCommit } from "../commit-analyser/parse-commit.js";
-import { setReleaseType } from "../commit-analyser/set-release-type.js";
+import { getReleaseType } from "../commit-analyser/get-release-type.js";
 import { debugConfig } from "../config/debug-config.js";
 import { getConfig } from "../config/index.js";
 import { checkBranch } from "../git/check-branch.js";
@@ -34,9 +33,6 @@ export const run = async (cliOptions: CliOptions, contextBase: ContextBase): Pro
   setLastRelease(context);
   const commits = getCommitsSinceRef(context);
   console.log("lastRelease", context.lastRelease);
-  for (const commit of commits) {
-    const parsedCommit = parseCommit(commit, context);
-    setReleaseType(parsedCommit, context);
-  }
+  getReleaseType(commits, context);
   console.log("exit", process.exitCode, process.exitCode ?? 0);
 };

--- a/src/commit-analyser/get-release-type.ts
+++ b/src/commit-analyser/get-release-type.ts
@@ -1,0 +1,57 @@
+import type { Context } from "../cli/cli.types.js";
+import type { ReleaseType } from "./commit-analyser.types.js";
+
+import { inspect } from "node:util";
+
+import { parseCommit } from "./parse-commit.js";
+import { setReleaseType } from "./set-release-type.js";
+
+/**
+ * Gets the release type from the commits committed since the previous release or the beginning.
+ * The release type can be one of the following, from most to least important:
+ * 1. `"major"`,
+ * 2. `"minor"`,
+ * 3. `"patch"`,
+ * 4. `null`.
+ * @param commits - The commits to analyse.
+ * @param context - The context where the CLI is running.
+ * @return The most important release type found if commits are parsed successfully, `null` if there are no commits or an error is thrown.
+ */
+export const getReleaseType = (commits: string[], context: Context): ReleaseType => {
+  const { config, logger } = context;
+  try {
+    const releaseTypes = new Set<ReleaseType>();
+    const totalCommits = commits.length;
+    if (totalCommits) {
+      for (const commit of commits) {
+        const parsedCommit = parseCommit(commit, context);
+        releaseTypes.add(setReleaseType(parsedCommit, context));
+      }
+      if (config.debug) logger.logDebug(inspect(releaseTypes), "commit-analyser:get-release-type");
+      const pluralRule = new Intl.PluralRules("en-GB", { type: "cardinal" });
+      const commitWord = pluralRule.select(totalCommits) === "one" ? "commit" : "commits";
+      const completeAnalysisSentence = `Analysis of ${totalCommits} ${commitWord} complete:`;
+      switch (true) {
+        case releaseTypes.has("major"):
+          logger.logSuccess(`${completeAnalysisSentence} major release.`);
+          return "major";
+        case releaseTypes.has("minor"):
+          logger.logSuccess(`${completeAnalysisSentence} minor release.`);
+          return "minor";
+        case releaseTypes.has("patch"):
+          logger.logSuccess(`${completeAnalysisSentence} patch release.`);
+          return "patch";
+        default:
+          logger.logSuccess(`${completeAnalysisSentence} no release.`);
+          return null;
+      }
+    }
+    logger.logWarn("No commits to analyse: no release.");
+    return null;
+  } catch (error) {
+    if (error instanceof Error) logger.logError(error.message);
+    else logger.logError(`Unknwon error: ${error}`);
+    process.exitCode = 1;
+    return null;
+  }
+};

--- a/test/commit-analyser/get-release-type.test.ts
+++ b/test/commit-analyser/get-release-type.test.ts
@@ -1,0 +1,81 @@
+import type { Config } from "../../src/config/config.types.js";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { getReleaseType } from "../../src/commit-analyser/get-release-type.js";
+
+import { DEFAULT_CONFIG } from "../../src/config/constants.js";
+
+describe("get release type", () => {
+  const commitIndent = " ".repeat(4);
+  const commitId = "commit 0123456789abcdef";
+  const commitAuthor = "Author: Contributor <0+userId@users.noreply.github.com>";
+  const commitDate = "Date:   Wed Jan 1 13:37:42 2025 +0000";
+  const commitBreakingChangeFooter = `${commitIndent}BREAKING CHANGE: some explanation.`;
+  const expectedDefaultConfig = DEFAULT_CONFIG as unknown as Config;
+  const mockedContext = {
+    cwd: "/fake/path",
+    env: {},
+    branch: "main",
+    config: expectedDefaultConfig,
+    logger: {
+      logDebug: vi.fn(),
+      logInfo: vi.fn(),
+      logError: vi.fn(),
+      logWarn: vi.fn(),
+      logSuccess: vi.fn()
+    }
+  };
+  const mockedCommitHead = `${commitId}\n${commitAuthor}\n${commitDate}`;
+  const mockedMajorCommit = `${mockedCommitHead}\n\n${commitIndent}feat!: add new breaking change feature`;
+  const mockedMajorCommitWithBreakingChangeFooter = `${mockedCommitHead}\n\n${commitIndent}feat: add new feature\n${commitIndent}\n${commitBreakingChangeFooter}`;
+  const mockedMinorCommit = `${mockedCommitHead}\n\n${commitIndent}feat: add new feature`;
+  const mockedPatchCommit = `${mockedCommitHead}\n\n${commitIndent}fix: fix bug`;
+  const mockedNoReleaseCommit = `${mockedCommitHead}\n\n${commitIndent}chore: some description`;
+
+  it("should return `major`", () => {
+    const mockedCommits = [
+      mockedNoReleaseCommit,
+      mockedMajorCommit,
+      mockedPatchCommit,
+      mockedMinorCommit
+    ];
+    expect(getReleaseType(mockedCommits, mockedContext)).toBe("major");
+  });
+  it("should return `major` if there is a breaking change footer", () => {
+    const mockedCommits = [
+      mockedNoReleaseCommit,
+      mockedMajorCommitWithBreakingChangeFooter,
+      mockedPatchCommit,
+      mockedMinorCommit
+    ];
+    expect(getReleaseType(mockedCommits, mockedContext)).toBe("major");
+  });
+  it("should return `minor`", () => {
+    const mockedCommits = [
+      mockedNoReleaseCommit,
+      mockedNoReleaseCommit,
+      mockedPatchCommit,
+      mockedMinorCommit
+    ];
+    expect(getReleaseType(mockedCommits, mockedContext)).toBe("minor");
+  });
+  it("should return `patch`", () => {
+    const mockedCommits = [
+      mockedNoReleaseCommit,
+      mockedPatchCommit,
+      mockedNoReleaseCommit,
+      mockedPatchCommit
+    ];
+    expect(getReleaseType(mockedCommits, mockedContext)).toBe("patch");
+  });
+  it("should return `null`", () => {
+    const mockedCommits = [
+      mockedNoReleaseCommit,
+      mockedNoReleaseCommit,
+      mockedNoReleaseCommit,
+      mockedNoReleaseCommit
+    ];
+    expect(getReleaseType(mockedCommits, mockedContext)).toBe(null);
+  });
+});


### PR DESCRIPTION
Get the most important release type from `"major"`, `"minor"`, `"patch"` or `null` from commits committed since the last release or the beginning.