### PR TITLE
fix(git): throw error if `git push --dry-run --no-verify` command returns a non-zero status

### DIFF
--- a/src/git/check-authorisation.ts
+++ b/src/git/check-authorisation.ts
@@ -34,6 +34,6 @@ export const checkAuthorisation = async (
   const { status, stderr } = gitCommandResult;
   if (status) {
     process.exitCode = status;
-    new Error(stderr);
+    throw new Error(stderr);
   }
 };


### PR DESCRIPTION
The error was not caught and the run proceeded as if the Git command returned a zero status.