### PR TITLE
build(renovate): enable lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,5 +20,8 @@
       "matchPackageNames": ["node", "npm", "pnpm"],
       "enabled": false
     }
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
At each Vitest update, the lock file kept the same versions of Vite and `esbuild`.

See https://github.com/vitest-dev/vitest/discussions/7520