### PR TITLE
ci(release): disable debug mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Release
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: node ./packages/cli/bin/index.js --debug
+        run: node ./packages/cli/bin/index.js


### PR DESCRIPTION
Log size limits might apply on GitHub when displaying GitHub Actions workflow jobs.