### PR TITLE
fix(github): add exit codes when errors are thrown

### DIFF
--- a/packages/github/src/get-associated-pull-requests.ts
+++ b/packages/github/src/get-associated-pull-requests.ts
@@ -41,19 +41,9 @@ export const getAssociatedPullRequests = async (
   const responseError: GitHubResponseError = await pullRequestResponse.json();
   const { message, documentation_url: documentationUrl } = responseError;
   const documentationReference = documentationUrl ? ` See ${documentationUrl}.` : "";
-  if (status === 409) {
-    process.exitCode = 409;
-    throw new Error(`There is a conflict with the requested URI ${uri}.${documentationReference}`);
-  }
-  if ((status === 403 && message.startsWith("API rate limit exceeded")) || status === 429) {
-    const errorMessage =
-      status === 403
-        ? "The GitHub API rate limit has been exceeded."
-        : "An abuse detection mechanism has been detected.";
+  if (status === 403 || status === 409 || status === 429) {
     process.exitCode = status;
-    throw new Error(
-      `${errorMessage} Please wait a few minutes and try again.${documentationReference}`
-    );
+    throw new Error(`${message}${documentationReference}`);
   }
   process.exitCode = status;
   throw new Error(message);

--- a/packages/github/test/fixtures/mocked-failure-fetches.ts
+++ b/packages/github/test/fixtures/mocked-failure-fetches.ts
@@ -32,7 +32,7 @@ export const mockedFailureFetches = [
         })
     },
     expectedError:
-      "The GitHub API rate limit has been exceeded. Please wait a few minutes and try again. See https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting."
+      "API rate limit exceeded for 0.0.0.0. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) See https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting."
   },
   {
     title: "should throw an error in case of request excess",
@@ -46,7 +46,7 @@ export const mockedFailureFetches = [
         })
     },
     expectedError:
-      "An abuse detection mechanism has been detected. Please wait a few minutes and try again. See https://developer.github.com/v3/#abuse-rate-limits."
+      "You have triggered an abuse detection mechanism. Please wait a few minutes before you try again. See https://developer.github.com/v3/#abuse-rate-limits."
   },
   {
     title: "should throw an error in case of other HTTP status code",

--- a/packages/github/test/get-asssociated-pull-requests.test.ts
+++ b/packages/github/test/get-asssociated-pull-requests.test.ts
@@ -22,6 +22,7 @@ it("should throw an error when the request fails", async () => {
 it.each(mockedFailureFetches)("$title", async ({ response, expectedError }) => {
   vi.mocked(mockedFetch).mockResolvedValue(response);
   await expect(getAssociatedPullRequests(mockedUri, mockedEnv)).rejects.toThrow(expectedError);
+  expect(process.exitCode).toBe(response.status);
 });
 it("should return the associated pull requests", async () => {
   const mockedPullRequests = [

--- a/packages/github/test/get-related-pull-requests-and-issues.test.ts
+++ b/packages/github/test/get-related-pull-requests-and-issues.test.ts
@@ -187,13 +187,18 @@ afterEach(() => {
 });
 
 it.each(mockedFailureFetches)("$title", async ({ response }) => {
+  vi.spyOn(process, "exit").mockImplementation(code => {
+    throw new Error(`process.exit(${code})`);
+  });
   vi.mocked(mockedFetch).mockResolvedValue(response);
+  process.exitCode = response.status;
   await expect(
     getRelatedPullRequestsAndIssues(mockedCommits, mockedDefaultContext)
   ).rejects.toThrow();
   expect(mockedLogger.logError).toHaveBeenCalledWith(
     "Failed to get related pull requests and issues."
   );
+  expect(process.exit).toHaveBeenCalledWith(response.status);
 });
 it("should complete context with references to no pull requests and issues if no commits are provided", async () => {
   await getRelatedPullRequestsAndIssues([], mockedDefaultContext);


### PR DESCRIPTION
The errors thrown were silent failures and did not make the release GitHub Actions workflow fail.