### PR TITLE
fix(npm): add `--no-git-checks` when pnpm is used

### DIFF
--- a/packages/npm/src/publish-to-registry.ts
+++ b/packages/npm/src/publish-to-registry.ts
@@ -50,6 +50,7 @@ export const publishToRegistry = async (
           // TODO: remove `--dry-run` flag to truly publish the release to the NPM registry
           const args = ["publish", "--dry-run", "--access", "public"];
           if (npmTag) args.push("--tag", npmTag);
+          if (packageManager === "pnpm") args.push("--no-git-checks");
           const packageManagerCommandResult = await runCommand(packageManager, args);
           const { status, stdout, stderr } = packageManagerCommandResult;
           const packageName = name || "root";

--- a/packages/npm/test/publish-to-registry.test.ts
+++ b/packages/npm/test/publish-to-registry.test.ts
@@ -128,6 +128,7 @@ describe.each(mockedNextReleases)("for package $name and version $version", next
     // TODO: remove `--dry-run` flag when releases are truly published to the NPM registry
     const args = ["publish", "--dry-run", "--access", "public"];
     if (nextRelease.npmTag) args.push("--tag", nextRelease.npmTag);
+    if (packageManager === "pnpm") args.push("--no-git-checks");
     it("should throw an error if the auth token is not defined", async () => {
       vi.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify(packageManifestContent));
       vi.mocked(getPackageManager).mockReturnValue(packageManager);


### PR DESCRIPTION
By default, pnpm checks whether the working tree is clean before publishing to NPM and fails if not.