### PR TITLE
fix(cli): display Git incompatible version found using `version` property or `null`

### DIFF
--- a/packages/cli/src/check-requirements/check-requirements.ts
+++ b/packages/cli/src/check-requirements/check-requirements.ts
@@ -29,7 +29,9 @@ export const checkRequirements = async (): Promise<void> => {
   }
   const gitVersion = coerce(runCommandSync("git", ["--version"]).stdout);
   if (!gitVersion || !isGitVersionCompatible(gitVersion.version)) {
-    logger.logError(`Git version ${GIT_MIN_VERSION} required. Found ${gitVersion}.`);
+    logger.logError(
+      `Git version ${GIT_MIN_VERSION} required. Found ${gitVersion?.version ?? null}.`
+    );
     process.exit(1);
   }
   process.exitCode = await cli();


### PR DESCRIPTION
`coerce()`, as implemented by `@release-change/semver`, returns an object or `null`, not a string.