### PR TITLE
fix(logger): separate normal scope from debug scope

### DIFF
--- a/packages/logger/src/logger.types.ts
+++ b/packages/logger/src/logger.types.ts
@@ -3,6 +3,7 @@ type LoggerFunction = (message: string) => void;
 export type LoggerContext = {
   isDebug: boolean;
   scope?: string;
+  debugScope?: string;
   type?: MessageType;
 };
 type MessageType = "info" | "error" | "warn" | "success";

--- a/packages/logger/src/set-logger.ts
+++ b/packages/logger/src/set-logger.ts
@@ -23,7 +23,7 @@ export const setLogger = (isDebug = false): Logger => {
       return scope;
     },
     logDebug: (message: string): void => {
-      console.debug(formatMessage(message, { ...loggerContext, scope: debugScope }));
+      console.debug(formatMessage(message, { ...loggerContext, debugScope: debugScope }));
     },
     logInfo: (message: string): void => {
       console.info(formatMessage(message, { ...loggerContext, scope: normalScope, type: "info" }));

--- a/packages/logger/src/set-prefix.ts
+++ b/packages/logger/src/set-prefix.ts
@@ -4,7 +4,7 @@ import { WORKSPACE_NAME } from "@release-change/shared";
 
 /**
  * Sets prefix for messages logged to the console according to the context provided by `loggerContext`:
- * - if the debug mode is activated, the prefix uses one of the following formats:
+ * - if the debug mode is activated and `debugScope` is defined as a string (even empty), the prefix uses one of the following formats:
  *   -`\x1b[1;34m[debug] <package name>\x1b[0m`,
  *   -`\x1b[1;34m[debug] <package name>:<scope name>\x1b[0m`;
  * - otherwise, the prefix uses one of the following formats:
@@ -15,9 +15,9 @@ import { WORKSPACE_NAME } from "@release-change/shared";
  * @return The prefix in the appropriate format.
  */
 export const setPrefix = (timestamp: number, loggerContext: LoggerContext): string => {
-  const { isDebug, scope } = loggerContext;
-  if (isDebug) {
-    if (scope) return `\x1b[1;34m[debug] ${WORKSPACE_NAME}:${scope}\x1b[0m`;
+  const { isDebug, scope, debugScope } = loggerContext;
+  if (isDebug && typeof debugScope === "string") {
+    if (debugScope) return `\x1b[1;34m[debug] ${WORKSPACE_NAME}:${debugScope}\x1b[0m`;
     return `\x1b[1;34m[debug] ${WORKSPACE_NAME}\x1b[0m`;
   }
   const time = Intl.DateTimeFormat(undefined, {

--- a/packages/logger/test/set-prefix.test.ts
+++ b/packages/logger/test/set-prefix.test.ts
@@ -9,8 +9,16 @@ const times = [
   { mockedTimestamp: 1735707843000, expectedTime: "05:04:03" },
   { mockedTimestamp: 1735738662000, expectedTime: "13:37:42" }
 ];
-const mockedLoggerContextForDebugMode: LoggerContext = { isDebug: true, scope: "my-scope" };
-const mockedLoggerContextForDebugModeWithoutScope: LoggerContext = { isDebug: true, scope: "" };
+const mockedLoggerContextForDebugMode: LoggerContext = { isDebug: true, debugScope: "my-scope" };
+const mockedLoggerContextForDebugModeWithoutScope: LoggerContext = {
+  isDebug: true,
+  debugScope: ""
+};
+const mockedLoggerContextForDebugModeWithoutDebugScope: LoggerContext = {
+  isDebug: true,
+  scope: "my-scope",
+  type: "info"
+};
 const mockedLoggerContextNotForDebugMode: LoggerContext = {
   isDebug: false,
   scope: "my-scope",
@@ -32,6 +40,11 @@ describe.each(times)(
     it("should return the appropriate prefix when debug mode is activated and there is no scope", () => {
       expect(setPrefix(mockedTimestamp, mockedLoggerContextForDebugModeWithoutScope)).toBe(
         `\x1b[1;34m[debug] ${WORKSPACE_NAME}\x1b[0m`
+      );
+    });
+    it("should return the appropriate prefix when debug mode is activated and there is no debug scope", () => {
+      expect(setPrefix(mockedTimestamp, mockedLoggerContextForDebugModeWithoutDebugScope)).toBe(
+        `[${expectedTime}] [${WORKSPACE_NAME}] [@${WORKSPACE_NAME}/my-scope] \u203a`
       );
     });
     it("should return the appropriate prefix when debug mode is deactivated", () => {


### PR DESCRIPTION
In debug mode, non-debug log messages were displayed with the debug prefix.