### PR TITLE
fix(github): access `sha` property

### DIFF
--- a/packages/github/src/get-related-pull-requests-and-issues.ts
+++ b/packages/github/src/get-related-pull-requests-and-issues.ts
@@ -35,7 +35,7 @@ export const getRelatedPullRequestsAndIssues = async (
       if (commitsWithSha.length) {
         for (const commitWithSha of commitsWithSha) {
           const pullRequests = await getAssociatedPullRequests(
-            `${repositoryEntryPoint}/commits/${commitWithSha}/pulls`,
+            `${repositoryEntryPoint}/commits/${commitWithSha.sha}/pulls`,
             getGitTags(commitWithSha, context),
             env
           );


### PR DESCRIPTION
The GitHub Actions workflow failed with exit code 166, no commits being found for malformed SHA.