### PR TITLE
fix(github): merge pull request and issue references sharing the same number together

### DIFF
--- a/packages/github/src/merge-references-by-number.ts
+++ b/packages/github/src/merge-references-by-number.ts
@@ -1,0 +1,32 @@
+import type { Reference } from "@release-change/shared";
+
+/**
+ * Merges references sharing the same number together.
+ *
+ * For each merged reference, the `gitTags` property is transformed into an array of unique Git tag values.
+ * @param references - The references to merge.
+ * @return An array of merged references.
+ */
+export const mergeReferencesByNumber = (references: Reference[]): Reference[] => {
+  const map = new Map();
+  for (const reference of references) {
+    const { number, isPullRequest, gitTags } = reference;
+    const existing = map.get(number);
+    if (existing) {
+      for (const gitTag of gitTags) {
+        existing.gitTagsSet.add(gitTag);
+      }
+    } else {
+      map.set(number, {
+        number,
+        isPullRequest,
+        gitTagsSet: new Set(reference.gitTags)
+      });
+    }
+  }
+  return Array.from(map.values(), obj => ({
+    number: obj.number,
+    isPullRequest: obj.isPullRequest,
+    gitTags: Array.from(obj.gitTagsSet)
+  }));
+};

--- a/packages/github/test/merge-references-by-number.test.ts
+++ b/packages/github/test/merge-references-by-number.test.ts
@@ -1,0 +1,69 @@
+import { assert, it } from "vitest";
+
+import { mergeReferencesByNumber } from "../src/merge-references-by-number.js";
+
+const mockedArraysWithObjectsToMerge = [
+  {
+    input: [
+      { number: 8203, isPullRequest: true, gitTags: ["v1.2.3"] },
+      { number: 2000, isPullRequest: true, gitTags: ["v1.2.3"] },
+      {
+        number: 8203,
+        isPullRequest: true,
+        gitTags: ["v1.2.3", "@monorepo/a@v1.0.0", "@monorepo/b@v1.1.0", "@monorepo/c@v0.1.0"]
+      },
+      { number: 772, isPullRequest: true, gitTags: ["v1.2.3"] },
+      { number: 1981, isPullRequest: true, gitTags: ["v1.2.3"] },
+      { number: 1981, isPullRequest: true, gitTags: ["@monorepo/c@v0.1.0"] },
+      { number: 1971, isPullRequest: true, gitTags: ["v1.2.3"] },
+      { number: 771, isPullRequest: true, gitTags: ["v1.2.3"] }
+    ],
+    expected: [
+      {
+        number: 8203,
+        isPullRequest: true,
+        gitTags: ["v1.2.3", "@monorepo/a@v1.0.0", "@monorepo/b@v1.1.0", "@monorepo/c@v0.1.0"]
+      },
+      { number: 2000, isPullRequest: true, gitTags: ["v1.2.3"] },
+      { number: 772, isPullRequest: true, gitTags: ["v1.2.3"] },
+      { number: 1981, isPullRequest: true, gitTags: ["v1.2.3", "@monorepo/c@v0.1.0"] },
+      { number: 1971, isPullRequest: true, gitTags: ["v1.2.3"] },
+      { number: 771, isPullRequest: true, gitTags: ["v1.2.3"] }
+    ]
+  },
+  {
+    input: [
+      { number: 8203, isPullRequest: false, gitTags: ["v1.2.3"] },
+      { number: 2000, isPullRequest: false, gitTags: ["v1.2.3"] },
+      {
+        number: 8203,
+        isPullRequest: false,
+        gitTags: ["v1.2.3", "@monorepo/a@v1.0.0", "@monorepo/b@v1.1.0", "@monorepo/c@v0.1.0"]
+      },
+      { number: 772, isPullRequest: false, gitTags: ["v1.2.3"] },
+      { number: 1981, isPullRequest: false, gitTags: ["v1.2.3"] },
+      { number: 1981, isPullRequest: false, gitTags: ["@monorepo/c@v0.1.0"] },
+      { number: 1971, isPullRequest: false, gitTags: ["v1.2.3"] },
+      { number: 771, isPullRequest: false, gitTags: ["v1.2.3"] }
+    ],
+    expected: [
+      {
+        number: 8203,
+        isPullRequest: false,
+        gitTags: ["v1.2.3", "@monorepo/a@v1.0.0", "@monorepo/b@v1.1.0", "@monorepo/c@v0.1.0"]
+      },
+      { number: 2000, isPullRequest: false, gitTags: ["v1.2.3"] },
+      { number: 772, isPullRequest: false, gitTags: ["v1.2.3"] },
+      { number: 1981, isPullRequest: false, gitTags: ["v1.2.3", "@monorepo/c@v0.1.0"] },
+      { number: 1971, isPullRequest: false, gitTags: ["v1.2.3"] },
+      { number: 771, isPullRequest: false, gitTags: ["v1.2.3"] }
+    ]
+  }
+];
+
+it.each(mockedArraysWithObjectsToMerge)(
+  "should return $expected from $input",
+  ({ input, expected }) => {
+    assert.deepEqual(mergeReferencesByNumber(input), expected);
+  }
+);


### PR DESCRIPTION
The `references` property was populated with duplicate references, even with different Git tags.