### PR TITLE
chore(tsconfig): add `types` property with `["node"]`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
+    "types": ["node"],
     "module": "NodeNext",
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
The default value is `[]` in TS 6, leading to TS2591 errors when using Node.js built-in modules.

See https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/
