### PR TITLE
fix(get-packages): stop throwing an error when no `packages` field is found in `pnpm-workspace.yaml`

### DIFF
--- a/packages/get-packages/src/get-packages.ts
+++ b/packages/get-packages/src/get-packages.ts
@@ -34,7 +34,9 @@ export const getPackages = async (context: ContextBase): Promise<Package[]> => {
       if (content) {
         try {
           const globPatterns = getPnpmGlobPatterns(content);
-          packages.push(...(await getPackagesFromGlobPatterns(globPatterns, cwd)));
+          if (globPatterns) {
+            packages.push(...(await getPackagesFromGlobPatterns(globPatterns, cwd)));
+          }
           if (debug) {
             logger.logDebug(`Packages found (including root package): ${packages.length}`);
             logger.logDebug(deepInspectObject(packages));

--- a/packages/get-packages/src/get-pnpm-glob-patterns.ts
+++ b/packages/get-packages/src/get-pnpm-glob-patterns.ts
@@ -1,13 +1,11 @@
 import type { GlobPatterns } from "./get-packages.types.js";
 
-import { formatDetailedError } from "@release-change/shared";
-
 /**
  * Gets glob patterns from the root `pnpm-workspace.yaml` file.
  * @param content - The content of root `pnpm-workspace.yaml`.
- * @return An object containing arrays of including and excluding glob patterns if there is a `packages` field.
+ * @return An object containing arrays of including and excluding glob patterns if there is a `packages` field, `null` otherwise.
  */
-export const getPnpmGlobPatterns = (content: string): GlobPatterns => {
+export const getPnpmGlobPatterns = (content: string): GlobPatterns | null => {
   const patterns: GlobPatterns = {
     include: [],
     exclude: ["**/node_modules/**"]
@@ -25,11 +23,5 @@ export const getPnpmGlobPatterns = (content: string): GlobPatterns => {
     }
   }
   if (patterns.include.length) return patterns;
-  throw formatDetailedError({
-    title: "Failed to get the glob patterns",
-    message: "The root `pnpm-workspace.yaml` file must have a `packages` field.",
-    details: {
-      output: "patterns.include.length: 0"
-    }
-  });
+  return null;
 };

--- a/packages/get-packages/test/get-packages.test.ts
+++ b/packages/get-packages/test/get-packages.test.ts
@@ -106,28 +106,6 @@ it("should throw an error if the package manager is npm and no `package.json` fi
   expect(addErrorToContext).toHaveBeenCalledWith(expectedError, mockedContextBase);
   assert.deepNestedInclude(mockedContextBase.errors, expectedError.cause);
 });
-it("should throw an error if the package manager is pnpm and the glob patterns do not return anything", async () => {
-  const expectedError = new Error(
-    "Failed to get the glob patterns: The root `pnpm-workspace.yaml` file must have a `packages` field.",
-    {
-      cause: {
-        title: "Failed to get the glob patterns",
-        message: "The root `pnpm-workspace.yaml` file must have a `packages` field.",
-        details: {
-          output: "patterns.include.length: 0"
-        }
-      }
-    }
-  );
-  vi.mocked(getPackageManager).mockReturnValue("pnpm");
-  vi.mocked(getRootPnpmWorkspaceManifest).mockReturnValue("no-packages:");
-  vi.mocked(getPnpmGlobPatterns).mockImplementation(() => {
-    throw expectedError;
-  });
-  await expect(getPackages(mockedContextBase)).rejects.toThrow();
-  expect(addErrorToContext).toHaveBeenCalledWith(expectedError, mockedContextBase);
-  assert.deepNestedInclude(mockedContextBase.errors, expectedError.cause);
-});
 it("should return one single package when the package manager is npm and the glob patterns do not return anything", async () => {
   vi.mocked(getPackageManager).mockReturnValue("npm");
   vi.mocked(getRootPackageManifest).mockReturnValue({ name: "my-package", version: "1.0.0" });
@@ -153,6 +131,12 @@ describe.each(npmPackages)("when the package manager is npm", ({ content, patter
 it("should return one single package when the package manager is pnpm and no `pnpm-workspace.yaml` file is found at the root", async () => {
   vi.mocked(getPackageManager).mockReturnValue("pnpm");
   vi.mocked(getRootPnpmWorkspaceManifest).mockReturnValue(null);
+  assert.deepEqual(await getPackages(mockedContextBase), expectedSinglePackage);
+});
+it("should return one single package when the package manager is pnpm and a `pnpm-workspace.yaml` file is found at the root and the glob patterns do not return anything", async () => {
+  vi.mocked(getPackageManager).mockReturnValue("pnpm");
+  vi.mocked(getRootPnpmWorkspaceManifest).mockReturnValue("no-packages:");
+  vi.mocked(getPnpmGlobPatterns).mockReturnValue(null);
   assert.deepEqual(await getPackages(mockedContextBase), expectedSinglePackage);
 });
 describe.each(pnpmPackages)("when the package manager is pnpm", ({

--- a/packages/get-packages/test/get-pnpm-glob-patterns.test.ts
+++ b/packages/get-packages/test/get-pnpm-glob-patterns.test.ts
@@ -3,22 +3,10 @@ import { assert, expect, it } from "vitest";
 import { getPnpmGlobPatterns } from "../src/index.js";
 import { pnpmWorkspaceManifestFiles } from "./fixtures/pnpm-workspace-manifest-files.js";
 
-it("should throw an error when no `packages` field is found in `pnpm-workspace.yaml`", () => {
+it("should return `null` when no `packages` field is found in `pnpm-workspace.yaml`", () => {
   const mockedContent = `catalog:
   chalk: ^4.1.2`;
-  expect(() => getPnpmGlobPatterns(mockedContent)).toThrow(
-    expect.objectContaining({
-      message:
-        "Failed to get the glob patterns: The root `pnpm-workspace.yaml` file must have a `packages` field.",
-      cause: {
-        title: "Failed to get the glob patterns",
-        message: "The root `pnpm-workspace.yaml` file must have a `packages` field.",
-        details: {
-          output: "patterns.include.length: 0"
-        }
-      }
-    })
-  );
+  expect(getPnpmGlobPatterns(mockedContent)).toBe(null);
 });
 it.each(
   pnpmWorkspaceManifestFiles


### PR DESCRIPTION
A non-monorepo repo using `pnpm-workspace.yaml` could see the release workflow fail.
