### PR TITLE
build(biome): remove `linter.rules.recommended` option

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -39,7 +39,6 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
       "correctness": {
         "noUnusedImports": "error",
         "noUnusedVariables": {


### PR DESCRIPTION
This option is deprecated since Biome 2.5.0.
