### PR TITLE
build(tsconfig): add references to each package `tsconfig.json`

### DIFF
--- a/packages/ci/tsconfig.json
+++ b/packages/ci/tsconfig.json
@@ -5,5 +5,16 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"]
+  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"],
+  "references": [
+    {
+      "path": "../shared/tsconfig.json"
+    },
+    {
+      "path": "../logger/tsconfig.json"
+    },
+    {
+      "path": "../config/tsconfig.json"
+    }
+  ]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,5 +5,37 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"]
+  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"],
+  "references": [
+    {
+      "path": "../shared/tsconfig.json"
+    },
+    {
+      "path": "../logger/tsconfig.json"
+    },
+    {
+      "path": "../semver/tsconfig.json"
+    },
+    {
+      "path": "../config/tsconfig.json"
+    },
+    {
+      "path": "../get-packages/tsconfig.json"
+    },
+    {
+      "path": "../commit-analyser/tsconfig.json"
+    },
+    {
+      "path": "../git/tsconfig.json"
+    },
+    {
+      "path": "../ci/tsconfig.json"
+    },
+    {
+      "path": "../github/tsconfig.json"
+    },
+    {
+      "path": "../release/tsconfig.json"
+    }
+  ]
 }

--- a/packages/commit-analyser/tsconfig.json
+++ b/packages/commit-analyser/tsconfig.json
@@ -5,5 +5,19 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"]
+  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"],
+  "references": [
+    {
+      "path": "../shared/tsconfig.json"
+    },
+    {
+      "path": "../logger/tsconfig.json"
+    },
+    {
+      "path": "../config/tsconfig.json"
+    },
+    {
+      "path": "../get-packages/tsconfig.json"
+    }
+  ]
 }

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -5,5 +5,13 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"]
+  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"],
+  "references": [
+    {
+      "path": "../shared/tsconfig.json"
+    },
+    {
+      "path": "../logger/tsconfig.json"
+    }
+  ]
 }

--- a/packages/get-packages/tsconfig.json
+++ b/packages/get-packages/tsconfig.json
@@ -5,5 +5,16 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"]
+  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"],
+  "references": [
+    {
+      "path": "../shared/tsconfig.json"
+    },
+    {
+      "path": "../logger/tsconfig.json"
+    },
+    {
+      "path": "../config/tsconfig.json"
+    }
+  ]
 }

--- a/packages/git/tsconfig.json
+++ b/packages/git/tsconfig.json
@@ -5,5 +5,19 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"]
+  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"],
+  "references": [
+    {
+      "path": "../shared/tsconfig.json"
+    },
+    {
+      "path": "../logger/tsconfig.json"
+    },
+    {
+      "path": "../semver/tsconfig.json"
+    },
+    {
+      "path": "../commit-analyser/tsconfig.json"
+    }
+  ]
 }

--- a/packages/github/tsconfig.json
+++ b/packages/github/tsconfig.json
@@ -5,5 +5,25 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"]
+  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"],
+  "references": [
+    {
+      "path": "../shared/tsconfig.json"
+    },
+    {
+      "path": "../logger/tsconfig.json"
+    },
+    {
+      "path": "../config/tsconfig.json"
+    },
+    {
+      "path": "../commit-analyser/tsconfig.json"
+    },
+    {
+      "path": "../git/tsconfig.json"
+    },
+    {
+      "path": "../ci/tsconfig.json"
+    }
+  ]
 }

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -5,5 +5,10 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"]
+  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"],
+  "references": [
+    {
+      "path": "../shared/tsconfig.json"
+    }
+  ]
 }

--- a/packages/npm/tsconfig.json
+++ b/packages/npm/tsconfig.json
@@ -5,5 +5,19 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"]
+  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"],
+  "references": [
+    {
+      "path": "../shared/tsconfig.json"
+    },
+    {
+      "path": "../logger/tsconfig.json"
+    },
+    {
+      "path": "../config/tsconfig.json"
+    },
+    {
+      "path": "../get-packages/tsconfig.json"
+    }
+  ]
 }

--- a/packages/release-notes-generator/tsconfig.json
+++ b/packages/release-notes-generator/tsconfig.json
@@ -5,5 +5,25 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"]
+  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"],
+  "references": [
+    {
+      "path": "../shared/tsconfig.json"
+    },
+    {
+      "path": "../logger/tsconfig.json"
+    },
+    {
+      "path": "../get-packages/tsconfig.json"
+    },
+    {
+      "path": "../commit-analyser/tsconfig.json"
+    },
+    {
+      "path": "../ci/tsconfig.json"
+    },
+    {
+      "path": "../github/tsconfig.json"
+    }
+  ]
 }

--- a/packages/release/tsconfig.json
+++ b/packages/release/tsconfig.json
@@ -5,5 +5,37 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"]
+  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"],
+  "references": [
+    {
+      "path": "../shared/tsconfig.json"
+    },
+    {
+      "path": "../logger/tsconfig.json"
+    },
+    {
+      "path": "../semver/tsconfig.json"
+    },
+    {
+      "path": "../config/tsconfig.json"
+    },
+    {
+      "path": "../get-packages/tsconfig.json"
+    },
+    {
+      "path": "../commit-analyser/tsconfig.json"
+    },
+    {
+      "path": "../git/tsconfig.json"
+    },
+    {
+      "path": "../github/tsconfig.json"
+    },
+    {
+      "path": "../npm/tsconfig.json"
+    },
+    {
+      "path": "../release-notes-generator/tsconfig.json"
+    }
+  ]
 }

--- a/packages/semver/tsconfig.json
+++ b/packages/semver/tsconfig.json
@@ -5,5 +5,6 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"]
+  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"],
+  "references": []
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -5,5 +5,6 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"]
+  "exclude": ["dist", "bin/**/*", "test/**/*", "node_modules"],
+  "references": []
 }


### PR DESCRIPTION
The lack of references in each package made the `tsc --build` command fail with TypeScript 7.