### PR TITLE
ci(pnpm): use pnpm 11.11.0

### DIFF
--- a/.github/actions/pnpm-node/action.yml
+++ b/.github/actions/pnpm-node/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       with:
-        version: 11
+        version: 11.11.0
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:


### PR DESCRIPTION
With version 11.12.0, the action-setup self-installer crashes.

Refs: pnpm/action-setup#276
