### PR TITLE
revert(pnpm): use latest pnpm 11 again

### DIFF
--- a/.github/actions/pnpm-node/action.yml
+++ b/.github/actions/pnpm-node/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       with:
-        version: 11.11.0
+        version: 11
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:


### PR DESCRIPTION
pnpm 11.13.0 fixes the action-setup self-installer crash appeared in 11.12.0.

Refs: e057e9f
