### PR TITLE
style: format test files

### DIFF
--- a/packages/cli/test/check-requirements.test.ts
+++ b/packages/cli/test/check-requirements.test.ts
@@ -58,23 +58,24 @@ beforeEach(() => {
   vi.spyOn(process, "version", "get").mockReturnValue("v20.18.3");
 });
 
-it.each(
-  formerLtsReleases
-)("should call `process.exit(1)` and display an error message if Node version %s is not compatible with those required", async mockedNodeVersion => {
-  const formattedRequiredNodeVersions = new Intl.ListFormat("en-GB", {
-    style: "long",
-    type: "disjunction"
-  }).format(REQUIRED_NODE_VERSIONS.replaceAll(/\^([.0-9]+)/gi, "$1+").split(" || "));
-  vi.spyOn(process, "version", "get").mockReturnValue(mockedNodeVersion);
-  vi.spyOn(process, "exit").mockImplementation(() => {
-    throw new Error("process.exit called with 1");
-  });
-  vi.mocked(isNodeVersionCompatible).mockReturnValue(false);
-  expect(checkRequirements()).rejects.toThrow("process.exit called with 1");
-  expect(mockedLogger.logError).toHaveBeenCalledWith(
-    `Required one of the following Node versions: ${formattedRequiredNodeVersions}. Found ${mockedNodeVersion}.`
-  );
-});
+it.each(formerLtsReleases)(
+  "should call `process.exit(1)` and display an error message if Node version %s is not compatible with those required",
+  async mockedNodeVersion => {
+    const formattedRequiredNodeVersions = new Intl.ListFormat("en-GB", {
+      style: "long",
+      type: "disjunction"
+    }).format(REQUIRED_NODE_VERSIONS.replaceAll(/\^([.0-9]+)/gi, "$1+").split(" || "));
+    vi.spyOn(process, "version", "get").mockReturnValue(mockedNodeVersion);
+    vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called with 1");
+    });
+    vi.mocked(isNodeVersionCompatible).mockReturnValue(false);
+    expect(checkRequirements()).rejects.toThrow("process.exit called with 1");
+    expect(mockedLogger.logError).toHaveBeenCalledWith(
+      `Required one of the following Node versions: ${formattedRequiredNodeVersions}. Found ${mockedNodeVersion}.`
+    );
+  }
+);
 it(`should call \`process.exit(1)\` and display an error message if Git version is less than ${GIT_MIN_VERSION}`, async () => {
   const mockedGitVersion = "git version 2.30.0";
   const mockedVersion = "2.30.0";

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -122,16 +122,16 @@ it("should configure CI environment", async () => {
   await run(mockedCliOptions, mockedContextBase);
   expect(mockedConfigureCiEnvironment).toHaveBeenCalledWith(mockedContextBase.env);
 });
-it.each(mockedPackages)("should get packages and determine if it is a monorepo", async ({
-  packages,
-  expectedToBeMonorepo
-}) => {
-  const mockedGetPackages = vi.mocked(getPackages).mockResolvedValue(packages);
-  const mockedIsMonorepo = vi.mocked(isMonorepo).mockReturnValue(expectedToBeMonorepo);
-  await run(mockedCliOptions, mockedContextBase);
-  expect(mockedGetPackages).toHaveBeenCalledWith(mockedContextBase);
-  expect(mockedIsMonorepo).toHaveBeenCalledWith(packages);
-});
+it.each(mockedPackages)(
+  "should get packages and determine if it is a monorepo",
+  async ({ packages, expectedToBeMonorepo }) => {
+    const mockedGetPackages = vi.mocked(getPackages).mockResolvedValue(packages);
+    const mockedIsMonorepo = vi.mocked(isMonorepo).mockReturnValue(expectedToBeMonorepo);
+    await run(mockedCliOptions, mockedContextBase);
+    expect(mockedGetPackages).toHaveBeenCalledWith(mockedContextBase);
+    expect(mockedIsMonorepo).toHaveBeenCalledWith(packages);
+  }
+);
 it("should call `checkRepository`", async () => {
   const mockedCheckRepository = vi.mocked(checkRepository).mockResolvedValue(0);
   await run(mockedCliOptions, mockedContextBase);

--- a/packages/cli/test/show-version.test.ts
+++ b/packages/cli/test/show-version.test.ts
@@ -16,10 +16,11 @@ vi.mock("@release-change/logger", () => ({
 }));
 vi.mocked(setLogger).mockReturnValue(mockedLogger);
 
-it.each(
-  cliOptions
-)(`should display a message saying \`v${expectedVersion}\` when using the \`%s\` command`, cliOption => {
-  vi.spyOn(childProcess, "execSync").mockReturnValue(`npx @release-change/cli ${cliOption}`);
-  showVersion();
-  expect(mockedLogger.logWithoutFormatting).toHaveBeenCalledWith(`v${expectedVersion}`);
-});
+it.each(cliOptions)(
+  `should display a message saying \`v${expectedVersion}\` when using the \`%s\` command`,
+  cliOption => {
+    vi.spyOn(childProcess, "execSync").mockReturnValue(`npx @release-change/cli ${cliOption}`);
+    showVersion();
+    expect(mockedLogger.logWithoutFormatting).toHaveBeenCalledWith(`v${expectedVersion}`);
+  }
+);

--- a/packages/commit-analyser/test/adjust-release-type.test.ts
+++ b/packages/commit-analyser/test/adjust-release-type.test.ts
@@ -188,18 +188,16 @@ vi.mock("@release-change/get-packages", () => ({
   getPackageDependencies: vi.fn()
 }));
 
-it.each(packagesSets)("should adjust the release type for the dependent packages", ({
-  packages,
-  internalDependencies,
-  releaseTypesPerPackage,
-  expected
-}) => {
-  vi.mocked(getPackageDependencies).mockImplementation((pathname: string) => {
-    const matchingKey = Object.keys(internalDependencies).find(key => pathname.includes(key));
-    return matchingKey ? (internalDependencies[matchingKey] ?? null) : null;
-  });
-  assert.deepEqual(
-    adjustReleaseType({ ...mockedContextInMonorepo, packages }, releaseTypesPerPackage),
-    expected
-  );
-});
+it.each(packagesSets)(
+  "should adjust the release type for the dependent packages",
+  ({ packages, internalDependencies, releaseTypesPerPackage, expected }) => {
+    vi.mocked(getPackageDependencies).mockImplementation((pathname: string) => {
+      const matchingKey = Object.keys(internalDependencies).find(key => pathname.includes(key));
+      return matchingKey ? (internalDependencies[matchingKey] ?? null) : null;
+    });
+    assert.deepEqual(
+      adjustReleaseType({ ...mockedContextInMonorepo, packages }, releaseTypesPerPackage),
+      expected
+    );
+  }
+);

--- a/packages/commit-analyser/test/parse-commit.test.ts
+++ b/packages/commit-analyser/test/parse-commit.test.ts
@@ -23,12 +23,12 @@ vi.mock("@release-change/shared", () => ({
 it.each(mockedCommits)("should parse a commit ($type)", ({ commit, expected }) => {
   assert.deepEqual(parseCommit(commit, mockedContext), expected);
 });
-it.each(mockedCommitsInMonorepo)("should parse a commit ($type) in a monorepo context", ({
-  commit,
-  expected
-}) => {
-  assert.deepEqual(parseCommit(commit, mockedContextInMonorepo), expected);
-});
+it.each(mockedCommitsInMonorepo)(
+  "should parse a commit ($type) in a monorepo context",
+  ({ commit, expected }) => {
+    assert.deepEqual(parseCommit(commit, mockedContextInMonorepo), expected);
+  }
+);
 it("should throw an error if the commit has no header", () => {
   const expectedError = new Error("Failed to parse commit: No header found.", {
     cause: {

--- a/packages/commit-analyser/test/set-release-type.test.ts
+++ b/packages/commit-analyser/test/set-release-type.test.ts
@@ -26,72 +26,62 @@ vi.mock("@release-change/logger", () => ({
 }));
 vi.mocked(setLogger).mockReturnValue(mockedLogger);
 
-it.each(
-  majorTypeCommits
-)("should trigger a major release for commit $message and footer $footer", ({
-  message,
-  footer
-}) => {
-  expect(setReleaseType(message, footer, mockedContext)).toBe("major");
-  expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedMajorLogMessage);
-});
-it.each(minorTypeCommits)("should trigger a minor release for commit $message", ({
-  message,
-  footer
-}) => {
-  expect(setReleaseType(message, footer, mockedContext)).toBe("minor");
-  expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedMinorLogMessage);
-});
-it.each(patchTypeCommits)("should trigger a patch release for commit $message", ({
-  message,
-  footer
-}) => {
-  expect(setReleaseType(message, footer, mockedContext)).toBe("patch");
-  expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedPatchLogMessage);
-});
-it.each(otherTypeCommits)("should not trigger a release for commit $message", ({
-  message,
-  footer
-}) => {
-  expect(setReleaseType(message, footer, mockedContext)).toBe(null);
-  expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedNoReleaseLogMessage);
-});
-it.each(
-  majorTypeCommitsWithUpperCasePrefix
-)("should trigger a major release for commit $message with upper case prefix", ({
-  message,
-  footer
-}) => {
-  expect(setReleaseType(message, footer, mockedContext)).toBe("major");
-  expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedMajorLogMessage);
-});
-it.each(
-  minorTypeCommitsWithUpperCasePrefix
-)("should trigger a minor release for commit $message with upper case prefix", ({
-  message,
-  footer
-}) => {
-  expect(setReleaseType(message, footer, mockedContext)).toBe("minor");
-  expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedMinorLogMessage);
-});
-it.each(
-  patchTypeCommitsWithUpperCasePrefix
-)("should trigger a patch release for commit $message with upper case prefix", ({
-  message,
-  footer
-}) => {
-  expect(setReleaseType(message, footer, mockedContext)).toBe("patch");
-  expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedPatchLogMessage);
-});
-it.each(
-  otherTypeCommitsWithUpperCasePrefix
-)("should not trigger a release for commit $message with upper case prefix", ({
-  message,
-  footer
-}) => {
-  expect(setReleaseType(message, footer, mockedContext)).toBe(null);
-  expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedNoReleaseLogMessage);
-});
+it.each(majorTypeCommits)(
+  "should trigger a major release for commit $message and footer $footer",
+  ({ message, footer }) => {
+    expect(setReleaseType(message, footer, mockedContext)).toBe("major");
+    expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedMajorLogMessage);
+  }
+);
+it.each(minorTypeCommits)(
+  "should trigger a minor release for commit $message",
+  ({ message, footer }) => {
+    expect(setReleaseType(message, footer, mockedContext)).toBe("minor");
+    expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedMinorLogMessage);
+  }
+);
+it.each(patchTypeCommits)(
+  "should trigger a patch release for commit $message",
+  ({ message, footer }) => {
+    expect(setReleaseType(message, footer, mockedContext)).toBe("patch");
+    expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedPatchLogMessage);
+  }
+);
+it.each(otherTypeCommits)(
+  "should not trigger a release for commit $message",
+  ({ message, footer }) => {
+    expect(setReleaseType(message, footer, mockedContext)).toBe(null);
+    expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedNoReleaseLogMessage);
+  }
+);
+it.each(majorTypeCommitsWithUpperCasePrefix)(
+  "should trigger a major release for commit $message with upper case prefix",
+  ({ message, footer }) => {
+    expect(setReleaseType(message, footer, mockedContext)).toBe("major");
+    expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedMajorLogMessage);
+  }
+);
+it.each(minorTypeCommitsWithUpperCasePrefix)(
+  "should trigger a minor release for commit $message with upper case prefix",
+  ({ message, footer }) => {
+    expect(setReleaseType(message, footer, mockedContext)).toBe("minor");
+    expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedMinorLogMessage);
+  }
+);
+it.each(patchTypeCommitsWithUpperCasePrefix)(
+  "should trigger a patch release for commit $message with upper case prefix",
+  ({ message, footer }) => {
+    expect(setReleaseType(message, footer, mockedContext)).toBe("patch");
+    expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedPatchLogMessage);
+  }
+);
+it.each(otherTypeCommitsWithUpperCasePrefix)(
+  "should not trigger a release for commit $message with upper case prefix",
+  ({ message, footer }) => {
+    expect(setReleaseType(message, footer, mockedContext)).toBe(null);
+    expect(mockedLogger.logInfo).toHaveBeenCalledWith(expectedNoReleaseLogMessage);
+  }
+);
 it("should not trigger a release for commits not following Conventional Commits syntax", () => {
   expect(
     setReleaseType("Commit not following Conventional Commits syntax", [], mockedContext)

--- a/packages/config/test/get-config.test.ts
+++ b/packages/config/test/get-config.test.ts
@@ -99,65 +99,66 @@ it("should get config according to all CLI options when all of them are set, whe
   };
   assert.deepEqual(await getConfig(mockedCliOptions), expectedConfig);
 });
-describe.each(
-  dependencyUpdateMethods
-)("with `dependencyUpdateMethod` set to %s", dependencyUpdateMethod => {
-  const mockedIsMonorepo = !!dependencyUpdateMethod;
-  const mockedCliOptions: CliOptions = {};
-  it("should get config according to config file", async () => {
-    const mockedConfigFile = {
-      ...expectedDefaultConfig,
-      branches: ["main", "next"],
-      repositoryUrl: mockedRepositoryUrl,
-      remoteName: mockedRemoteName,
-      isMonorepo: mockedIsMonorepo,
-      dependencyUpdateMethod
-    };
-    const expectedConfig = {
-      branches: ["main", "next"],
-      repositoryUrl: mockedRepositoryUrl,
-      remoteName: mockedRemoteName,
-      releaseType: expectedDefaultConfig.releaseType,
-      isMonorepo: mockedIsMonorepo,
-      dependencyUpdateMethod,
-      debug: false,
-      dryRun: false
-    };
-    vi.mocked(getConfigFile).mockReturnValue(mockedConfigFile);
-    assert.deepEqual(await getConfig(mockedCliOptions, mockedIsMonorepo), expectedConfig);
-  });
-  it("should get config according to config file with custom `releaseType`", async () => {
-    const mockedConfigFile = {
-      ...expectedDefaultConfig,
-      branches: ["main", "next"],
-      repositoryUrl: mockedRepositoryUrl,
-      remoteName: mockedRemoteName,
-      releaseType: {
-        next: {
-          channel: "rc"
-        }
-      },
-      isMonorepo: mockedIsMonorepo,
-      dependencyUpdateMethod
-    };
-    const expectedConfig = {
-      branches: ["main", "next"],
-      repositoryUrl: mockedRepositoryUrl,
-      remoteName: mockedRemoteName,
-      releaseType: {
-        next: {
-          channel: "rc"
-        }
-      },
-      isMonorepo: mockedIsMonorepo,
-      dependencyUpdateMethod,
-      debug: false,
-      dryRun: false
-    };
-    vi.mocked(getConfigFile).mockReturnValue(mockedConfigFile);
-    assert.deepEqual(await getConfig(mockedCliOptions, mockedIsMonorepo), expectedConfig);
-  });
-});
+describe.each(dependencyUpdateMethods)(
+  "with `dependencyUpdateMethod` set to %s",
+  dependencyUpdateMethod => {
+    const mockedIsMonorepo = !!dependencyUpdateMethod;
+    const mockedCliOptions: CliOptions = {};
+    it("should get config according to config file", async () => {
+      const mockedConfigFile = {
+        ...expectedDefaultConfig,
+        branches: ["main", "next"],
+        repositoryUrl: mockedRepositoryUrl,
+        remoteName: mockedRemoteName,
+        isMonorepo: mockedIsMonorepo,
+        dependencyUpdateMethod
+      };
+      const expectedConfig = {
+        branches: ["main", "next"],
+        repositoryUrl: mockedRepositoryUrl,
+        remoteName: mockedRemoteName,
+        releaseType: expectedDefaultConfig.releaseType,
+        isMonorepo: mockedIsMonorepo,
+        dependencyUpdateMethod,
+        debug: false,
+        dryRun: false
+      };
+      vi.mocked(getConfigFile).mockReturnValue(mockedConfigFile);
+      assert.deepEqual(await getConfig(mockedCliOptions, mockedIsMonorepo), expectedConfig);
+    });
+    it("should get config according to config file with custom `releaseType`", async () => {
+      const mockedConfigFile = {
+        ...expectedDefaultConfig,
+        branches: ["main", "next"],
+        repositoryUrl: mockedRepositoryUrl,
+        remoteName: mockedRemoteName,
+        releaseType: {
+          next: {
+            channel: "rc"
+          }
+        },
+        isMonorepo: mockedIsMonorepo,
+        dependencyUpdateMethod
+      };
+      const expectedConfig = {
+        branches: ["main", "next"],
+        repositoryUrl: mockedRepositoryUrl,
+        remoteName: mockedRemoteName,
+        releaseType: {
+          next: {
+            channel: "rc"
+          }
+        },
+        isMonorepo: mockedIsMonorepo,
+        dependencyUpdateMethod,
+        debug: false,
+        dryRun: false
+      };
+      vi.mocked(getConfigFile).mockReturnValue(mockedConfigFile);
+      assert.deepEqual(await getConfig(mockedCliOptions, mockedIsMonorepo), expectedConfig);
+    });
+  }
+);
 it("should get config according to CLI options rather than config file", async () => {
   const mockedConfigFile = {
     ...expectedDefaultConfig,

--- a/packages/config/test/switch-url-to-https-protocol.test.ts
+++ b/packages/config/test/switch-url-to-https-protocol.test.ts
@@ -5,8 +5,9 @@ import { mockedRemoteUrls } from "./fixtures/mocked-remote-urls.js";
 
 const expectedHttpsRemoteUrl = "https://github.com/user-id/repo-name.git";
 
-it.each(
-  mockedRemoteUrls
-)('should return the URL "%s" according to the HTTPS protocol', mockedRemoteUrl => {
-  expect(switchUrlToHttpsProtocol(mockedRemoteUrl)).toBe(expectedHttpsRemoteUrl);
-});
+it.each(mockedRemoteUrls)(
+  'should return the URL "%s" according to the HTTPS protocol',
+  mockedRemoteUrl => {
+    expect(switchUrlToHttpsProtocol(mockedRemoteUrl)).toBe(expectedHttpsRemoteUrl);
+  }
+);

--- a/packages/config/test/switch-url-to-ssh-protocol.test.ts
+++ b/packages/config/test/switch-url-to-ssh-protocol.test.ts
@@ -5,8 +5,9 @@ import { mockedRemoteUrls } from "./fixtures/mocked-remote-urls.js";
 
 const expectedSshRemoteUrl = "ssh://git@github.com/user-id/repo-name.git";
 
-it.each(
-  mockedRemoteUrls
-)('should return the URL "%s" according to the SSH protocol', mockedRemoteUrl => {
-  expect(switchUrlToSshProtocol(mockedRemoteUrl)).toBe(expectedSshRemoteUrl);
-});
+it.each(mockedRemoteUrls)(
+  'should return the URL "%s" according to the SSH protocol',
+  mockedRemoteUrl => {
+    expect(switchUrlToSshProtocol(mockedRemoteUrl)).toBe(expectedSshRemoteUrl);
+  }
+);

--- a/packages/get-packages/test/get-npm-glob-patterns.test.ts
+++ b/packages/get-packages/test/get-npm-glob-patterns.test.ts
@@ -3,9 +3,9 @@ import { assert, it } from "vitest";
 import { getNpmGlobPatterns } from "../src/index.js";
 import { packageManifestFiles } from "./fixtures/package-manifest-files.js";
 
-it.each(packageManifestFiles)("should get the including patterns from `package.json`", ({
-  content,
-  patterns
-}) => {
-  assert.deepEqual(getNpmGlobPatterns(content), patterns);
-});
+it.each(packageManifestFiles)(
+  "should get the including patterns from `package.json`",
+  ({ content, patterns }) => {
+    assert.deepEqual(getNpmGlobPatterns(content), patterns);
+  }
+);

--- a/packages/get-packages/test/get-package-dependencies.test.ts
+++ b/packages/get-packages/test/get-package-dependencies.test.ts
@@ -37,13 +37,11 @@ it("should return an empty array if the package manifest file does not have the 
   );
   assert.deepEqual(getPackageDependencies(mockedPath), []);
 });
-it.each(
-  mockedPackageManifests
-)("should return an array of the dependencies found in the `dependencies` and `devDependencies` properties", ({
-  content,
-  expected
-}) => {
-  vi.spyOn(fs, "existsSync").mockReturnValue(true);
-  vi.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify(content));
-  assert.deepEqual(getPackageDependencies(mockedPath), expected);
-});
+it.each(mockedPackageManifests)(
+  "should return an array of the dependencies found in the `dependencies` and `devDependencies` properties",
+  ({ content, expected }) => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    vi.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify(content));
+    assert.deepEqual(getPackageDependencies(mockedPath), expected);
+  }
+);

--- a/packages/get-packages/test/get-packages.test.ts
+++ b/packages/get-packages/test/get-packages.test.ts
@@ -139,23 +139,25 @@ it("should return one single package when the package manager is pnpm and a `pnp
   vi.mocked(getPnpmGlobPatterns).mockReturnValue(null);
   assert.deepEqual(await getPackages(mockedContextBase), expectedSinglePackage);
 });
-describe.each(pnpmPackages)("when the package manager is pnpm", ({
-  content,
-  patterns,
-  packages
-}) => {
-  it("should return one single package when the glob patterns return an empty array of packages", async () => {
-    vi.mocked(getPackageManager).mockReturnValue("npm");
-    vi.mocked(getRootPnpmWorkspaceManifest).mockReturnValue(content);
-    vi.mocked(getPnpmGlobPatterns).mockReturnValue(patterns);
-    vi.mocked(getPackagesFromGlobPatterns).mockResolvedValue([]);
-    assert.deepEqual(await getPackages(mockedContextBase), expectedSinglePackage);
-  });
-  it("should return the correct packages when the glob patterns return packages", async () => {
-    vi.mocked(getPackageManager).mockReturnValue("npm");
-    vi.mocked(getRootPnpmWorkspaceManifest).mockReturnValue(content);
-    vi.mocked(getPnpmGlobPatterns).mockReturnValue(patterns);
-    vi.mocked(getPackagesFromGlobPatterns).mockResolvedValue(packages);
-    assert.deepEqual(await getPackages(mockedContextBase), [...expectedSinglePackage, ...packages]);
-  });
-});
+describe.each(pnpmPackages)(
+  "when the package manager is pnpm",
+  ({ content, patterns, packages }) => {
+    it("should return one single package when the glob patterns return an empty array of packages", async () => {
+      vi.mocked(getPackageManager).mockReturnValue("npm");
+      vi.mocked(getRootPnpmWorkspaceManifest).mockReturnValue(content);
+      vi.mocked(getPnpmGlobPatterns).mockReturnValue(patterns);
+      vi.mocked(getPackagesFromGlobPatterns).mockResolvedValue([]);
+      assert.deepEqual(await getPackages(mockedContextBase), expectedSinglePackage);
+    });
+    it("should return the correct packages when the glob patterns return packages", async () => {
+      vi.mocked(getPackageManager).mockReturnValue("npm");
+      vi.mocked(getRootPnpmWorkspaceManifest).mockReturnValue(content);
+      vi.mocked(getPnpmGlobPatterns).mockReturnValue(patterns);
+      vi.mocked(getPackagesFromGlobPatterns).mockResolvedValue(packages);
+      assert.deepEqual(await getPackages(mockedContextBase), [
+        ...expectedSinglePackage,
+        ...packages
+      ]);
+    });
+  }
+);

--- a/packages/get-packages/test/get-pnpm-glob-patterns.test.ts
+++ b/packages/get-packages/test/get-pnpm-glob-patterns.test.ts
@@ -8,11 +8,9 @@ it("should return `null` when no `packages` field is found in `pnpm-workspace.ya
   chalk: ^4.1.2`;
   expect(getPnpmGlobPatterns(mockedContent)).toBe(null);
 });
-it.each(
-  pnpmWorkspaceManifestFiles
-)("should get the including and excluding patterns from `pnpm-workspace.yaml`", ({
-  content,
-  patterns
-}) => {
-  assert.deepEqual(getPnpmGlobPatterns(content), patterns);
-});
+it.each(pnpmWorkspaceManifestFiles)(
+  "should get the including and excluding patterns from `pnpm-workspace.yaml`",
+  ({ content, patterns }) => {
+    assert.deepEqual(getPnpmGlobPatterns(content), patterns);
+  }
+);

--- a/packages/git/test/commit.test.ts
+++ b/packages/git/test/commit.test.ts
@@ -37,14 +37,15 @@ it("should throw an error if the commit message is empty", async () => {
   vi.mocked(formatDetailedError).mockReturnValue(expectedError);
   await expect(commit("", mockedCwd)).rejects.toThrow(expectedError);
 });
-it.each(
-  mockedCommitMessages
-)('should run the command with the commit message `"%s"` if correctly provided', async mockedCommitMessage => {
-  const mockedCommand = vi
-    .mocked(runCommand)
-    .mockResolvedValue({ status: 0, stdout: "", stderr: "" });
-  await commit(mockedCommitMessage, mockedCwd);
-  expect(mockedCommand).toHaveBeenCalledWith("git", ["commit", "-m", mockedCommitMessage], {
-    cwd: mockedCwd
-  });
-});
+it.each(mockedCommitMessages)(
+  'should run the command with the commit message `"%s"` if correctly provided',
+  async mockedCommitMessage => {
+    const mockedCommand = vi
+      .mocked(runCommand)
+      .mockResolvedValue({ status: 0, stdout: "", stderr: "" });
+    await commit(mockedCommitMessage, mockedCwd);
+    expect(mockedCommand).toHaveBeenCalledWith("git", ["commit", "-m", mockedCommitMessage], {
+      cwd: mockedCwd
+    });
+  }
+);

--- a/packages/git/test/get-commits-since-ref.test.ts
+++ b/packages/git/test/get-commits-since-ref.test.ts
@@ -94,51 +94,47 @@ it("should log an error message when an error is caught", () => {
   assert.deepNestedInclude(mockedContext.errors, expectedError.cause);
   mockedProcessExit.mockRestore();
 });
-describe.each(commitsSets)("when `context.config.isMonorepo` is $isMonorepo", ({
-  context,
-  commits,
-  expected,
-  expectedNumber,
-  commandWithTag,
-  commandWithoutTag
-}) => {
-  const mockedCommandResultWithNoCommits = {
-    status: 0,
-    stdout: "",
-    stderr: ""
-  };
-  const argsWithTag = commandWithTag.split(" ").slice(1);
-  const argsWithoutTag = commandWithoutTag.split(" ").slice(1);
-  it("should return an array of commits", () => {
-    vi.mocked(runCommandSync).mockReturnValue({
+describe.each(commitsSets)(
+  "when `context.config.isMonorepo` is $isMonorepo",
+  ({ context, commits, expected, expectedNumber, commandWithTag, commandWithoutTag }) => {
+    const mockedCommandResultWithNoCommits = {
       status: 0,
-      stdout: commits,
+      stdout: "",
       stderr: ""
+    };
+    const argsWithTag = commandWithTag.split(" ").slice(1);
+    const argsWithoutTag = commandWithoutTag.split(" ").slice(1);
+    it("should return an array of commits", () => {
+      vi.mocked(runCommandSync).mockReturnValue({
+        status: 0,
+        stdout: commits,
+        stderr: ""
+      });
+      assert.deepEqual(getCommitsSinceRef(context), expected);
+      expect(mockedLogger.logInfo).toHaveBeenCalledWith(`Found ${expectedNumber} commits.`);
     });
-    assert.deepEqual(getCommitsSinceRef(context), expected);
-    expect(mockedLogger.logInfo).toHaveBeenCalledWith(`Found ${expectedNumber} commits.`);
-  });
-  it("should return an empty array when no commits are found", () => {
-    vi.mocked(runCommandSync).mockReturnValue(mockedCommandResultWithNoCommits);
-    assert.deepEqual(getCommitsSinceRef(context), []);
-    expect(mockedLogger.logInfo).toHaveBeenCalledWith("Found 0 commits.");
-  });
-  it(`should run \`${commandWithoutTag}\` when there are no Git tags`, () => {
-    vi.mocked(runCommandSync).mockReturnValue(mockedCommandResultWithNoCommits);
-    getCommitsSinceRef(context);
-    expect(runCommandSync).toHaveBeenCalledWith("git", argsWithoutTag, { cwd: mockedCwd });
-    expect(mockedLogger.logInfo).toHaveBeenCalledWith("Retrieving all commits…");
-  });
-  it(`should run \`${commandWithTag}\` when the ref is Git tag "v1.0.0"`, () => {
-    vi.mocked(runCommandSync).mockReturnValue(mockedCommandResultWithNoCommits);
-    getCommitsSinceRef({
-      ...context,
-      lastRelease: {
-        ref: "v1.0.0",
-        packages: [{ name: "", pathname: ".", gitTag: "v1.0.0", version: "1.0.0" }]
-      }
+    it("should return an empty array when no commits are found", () => {
+      vi.mocked(runCommandSync).mockReturnValue(mockedCommandResultWithNoCommits);
+      assert.deepEqual(getCommitsSinceRef(context), []);
+      expect(mockedLogger.logInfo).toHaveBeenCalledWith("Found 0 commits.");
     });
-    expect(runCommandSync).toHaveBeenCalledWith("git", argsWithTag, { cwd: mockedCwd });
-    expect(mockedLogger.logInfo).toHaveBeenCalledWith("Retrieving commits since v1.0.0…");
-  });
-});
+    it(`should run \`${commandWithoutTag}\` when there are no Git tags`, () => {
+      vi.mocked(runCommandSync).mockReturnValue(mockedCommandResultWithNoCommits);
+      getCommitsSinceRef(context);
+      expect(runCommandSync).toHaveBeenCalledWith("git", argsWithoutTag, { cwd: mockedCwd });
+      expect(mockedLogger.logInfo).toHaveBeenCalledWith("Retrieving all commits…");
+    });
+    it(`should run \`${commandWithTag}\` when the ref is Git tag "v1.0.0"`, () => {
+      vi.mocked(runCommandSync).mockReturnValue(mockedCommandResultWithNoCommits);
+      getCommitsSinceRef({
+        ...context,
+        lastRelease: {
+          ref: "v1.0.0",
+          packages: [{ name: "", pathname: ".", gitTag: "v1.0.0", version: "1.0.0" }]
+        }
+      });
+      expect(runCommandSync).toHaveBeenCalledWith("git", argsWithTag, { cwd: mockedCwd });
+      expect(mockedLogger.logInfo).toHaveBeenCalledWith("Retrieving commits since v1.0.0…");
+    });
+  }
+);

--- a/packages/git/test/get-latest-valid-tag.test.ts
+++ b/packages/git/test/get-latest-valid-tag.test.ts
@@ -222,32 +222,27 @@ it("should return `null` if no valid Git tag is available", () => {
   vi.mocked(getAllTags).mockReturnValue(mockedInvalidGitTags);
   expect(getLatestValidTag(mockedContext)).toBe(null);
 });
-it.each(mockedContexts)("should return the first relevant Git tag for branch $branch", ({
-  branch,
-  gitTag
-}) => {
-  const context = { ...mockedContext, branch };
-  vi.mocked(getAllTags).mockReturnValue(mockedValidGitTags);
-  expect(getLatestValidTag(context)).toBe(gitTag);
-});
-it.each(
-  mockedContextsInMonorepo
-)("should return the first relevant Git tag for branch $branch in a monorepo", ({
-  branch,
-  gitTag
-}) => {
-  const context = { ...mockedContextInMonorepo, branch };
-  vi.mocked(getAllTags).mockReturnValue(mockedValidGitTagsInMonorepo);
-  expect(getLatestValidTag(context)).toBe(gitTag);
-});
-it.each(
-  mockedPackages
-)("should return $expectedGitTag for package $name and branch $branch in a monorepo", ({
-  name,
-  branch,
-  expectedGitTag
-}) => {
-  const context = { ...mockedContextInMonorepo, branch };
-  vi.mocked(getAllTags).mockReturnValue([...mockedValidGitTags, ...mockedValidGitTagsInMonorepo]);
-  expect(getLatestValidTag(context, name)).toBe(expectedGitTag);
-});
+it.each(mockedContexts)(
+  "should return the first relevant Git tag for branch $branch",
+  ({ branch, gitTag }) => {
+    const context = { ...mockedContext, branch };
+    vi.mocked(getAllTags).mockReturnValue(mockedValidGitTags);
+    expect(getLatestValidTag(context)).toBe(gitTag);
+  }
+);
+it.each(mockedContextsInMonorepo)(
+  "should return the first relevant Git tag for branch $branch in a monorepo",
+  ({ branch, gitTag }) => {
+    const context = { ...mockedContextInMonorepo, branch };
+    vi.mocked(getAllTags).mockReturnValue(mockedValidGitTagsInMonorepo);
+    expect(getLatestValidTag(context)).toBe(gitTag);
+  }
+);
+it.each(mockedPackages)(
+  "should return $expectedGitTag for package $name and branch $branch in a monorepo",
+  ({ name, branch, expectedGitTag }) => {
+    const context = { ...mockedContextInMonorepo, branch };
+    vi.mocked(getAllTags).mockReturnValue([...mockedValidGitTags, ...mockedValidGitTagsInMonorepo]);
+    expect(getLatestValidTag(context, name)).toBe(expectedGitTag);
+  }
+);

--- a/packages/git/test/get-remote-name.test.ts
+++ b/packages/git/test/get-remote-name.test.ts
@@ -24,15 +24,17 @@ it("should return `null` when there are no tracked repositories", async () => {
   vi.mocked(getTrackedRepositories).mockReturnValue(Promise.resolve(""));
   expect(await getRemoteName(mockedContext)).toBe(null);
 });
-it.each(
-  mockedRemotesWithNoPush
-)('should return `null` when no remote name for push is defined (only "%s")', async mockedRemoteFetch => {
-  vi.mocked(getTrackedRepositories).mockReturnValue(Promise.resolve(mockedRemoteFetch));
-  expect(await getRemoteName(mockedContext)).toBe(null);
-});
-it.each(
-  mockedRemotes
-)('should return the first remote name for push found ("%s"), that is "%s"', async (mockedRemote, expectedMockedRemoteName) => {
-  vi.mocked(getTrackedRepositories).mockReturnValue(Promise.resolve(mockedRemote));
-  expect(await getRemoteName(mockedContext)).toBe(expectedMockedRemoteName);
-});
+it.each(mockedRemotesWithNoPush)(
+  'should return `null` when no remote name for push is defined (only "%s")',
+  async mockedRemoteFetch => {
+    vi.mocked(getTrackedRepositories).mockReturnValue(Promise.resolve(mockedRemoteFetch));
+    expect(await getRemoteName(mockedContext)).toBe(null);
+  }
+);
+it.each(mockedRemotes)(
+  'should return the first remote name for push found ("%s"), that is "%s"',
+  async (mockedRemote, expectedMockedRemoteName) => {
+    vi.mocked(getTrackedRepositories).mockReturnValue(Promise.resolve(mockedRemote));
+    expect(await getRemoteName(mockedContext)).toBe(expectedMockedRemoteName);
+  }
+);

--- a/packages/git/test/set-branch-name.test.ts
+++ b/packages/git/test/set-branch-name.test.ts
@@ -54,10 +54,9 @@ it("should throw an error when there are no next releases", () => {
   vi.mocked(formatDetailedError).mockReturnValue(expectedError);
   expect(() => setBranchName("branch", [])).toThrow(expectedError);
 });
-it.each(mockedBranchNames)("should set branch name as $expected", ({
-  branch,
-  nextRelease,
-  expected
-}) => {
-  expect(setBranchName(branch, nextRelease)).toBe(expected);
-});
+it.each(mockedBranchNames)(
+  "should set branch name as $expected",
+  ({ branch, nextRelease, expected }) => {
+    expect(setBranchName(branch, nextRelease)).toBe(expected);
+  }
+);

--- a/packages/github/test/create-pull-request.test.ts
+++ b/packages/github/test/create-pull-request.test.ts
@@ -105,71 +105,68 @@ it("should throw an error if the head branch is empty", () => {
     "The head branch must not be empty."
   );
 });
-describe.each(
-  mockedPullRequests
-)("when `nextRelease` is $nextRelease and `isAutoMerge` is $isAutoMerge", async ({
-  isMonorepo,
-  isAutoMerge,
-  nextRelease,
-  expectedTitle,
-  expectedBody
-}) => {
-  const context = isMonorepo
-    ? mockedContextWithNextReleaseInMonorepo
-    : mockedContextWithNextRelease;
-  it("should throw an error when the request fails", () => {
-    vi.mocked(mockedFetch).mockRejectedValue(new Error("Failed to request the URI."));
-    expect(createPullRequest(mockedHeadBranch, mockedMergeOptions, context)).rejects.toThrow(
-      "Failed to request the URI."
-    );
-  });
-  it.each(mockedFailureFetches)("$title", async ({ response, expectedError }) => {
-    vi.mocked(mockedFetch).mockResolvedValue({
-      ...response,
-      json: () => Promise.resolve({ message: response.statusText })
-    });
-    vi.mocked(formatDetailedError).mockReturnValue(expectedError);
-    await expect(createPullRequest(mockedHeadBranch, mockedMergeOptions, context)).rejects.toThrow(
-      expectedError
-    );
-    expect(mockedLogger.logError).toHaveBeenCalledWith("Failed to create the pull request.");
-    expect(process.exitCode).toBe(response.status);
-  });
-  it("should create a pull request", async () => {
-    const mockedNumber = 123;
-    const mockedNodeId = "fake_ID";
+describe.each(mockedPullRequests)(
+  "when `nextRelease` is $nextRelease and `isAutoMerge` is $isAutoMerge",
+  async ({ isMonorepo, isAutoMerge, nextRelease, expectedTitle, expectedBody }) => {
     const context = isMonorepo
-      ? { ...mockedContextInMonorepo, nextRelease }
-      : { ...mockedContext, nextRelease };
-    vi.mocked(mockedFetch).mockResolvedValue({
-      status: 201,
-      statusText: "Created",
-      json: () => Promise.resolve({ number: mockedNumber, node_id: mockedNodeId })
+      ? mockedContextWithNextReleaseInMonorepo
+      : mockedContextWithNextRelease;
+    it("should throw an error when the request fails", () => {
+      vi.mocked(mockedFetch).mockRejectedValue(new Error("Failed to request the URI."));
+      expect(createPullRequest(mockedHeadBranch, mockedMergeOptions, context)).rejects.toThrow(
+        "Failed to request the URI."
+      );
     });
-    const returnedReference = await createPullRequest(
-      mockedHeadBranch,
-      { ...mockedMergeOptions, autoMergeAllowed: isAutoMerge },
-      context
-    );
-    expect(mockedFetch).toHaveBeenCalledWith(mockedUriForPullRequests, {
-      method: "POST",
-      headers: {
-        Accept: GITHUB_API_ACCEPT_HEADER,
-        Authorization: `Bearer ${mockedIssuePRToken}`,
-        "Content-Type": "application/json",
-        "X-GitHub-Api-Version": GITHUB_API_VERSION
-      },
-      body: JSON.stringify({
-        title: expectedTitle,
-        head: mockedHeadBranch,
-        base: context.branch,
-        body: expectedBody
-      })
+    it.each(mockedFailureFetches)("$title", async ({ response, expectedError }) => {
+      vi.mocked(mockedFetch).mockResolvedValue({
+        ...response,
+        json: () => Promise.resolve({ message: response.statusText })
+      });
+      vi.mocked(formatDetailedError).mockReturnValue(expectedError);
+      await expect(
+        createPullRequest(mockedHeadBranch, mockedMergeOptions, context)
+      ).rejects.toThrow(expectedError);
+      expect(mockedLogger.logError).toHaveBeenCalledWith("Failed to create the pull request.");
+      expect(process.exitCode).toBe(response.status);
     });
-    expect(mockedLogger.logSuccess).toHaveBeenCalledWith("Created the pull request successfully.");
-    assert.deepEqual(returnedReference, {
-      pullRequestNumber: mockedNumber,
-      pullRequestId: mockedNodeId
+    it("should create a pull request", async () => {
+      const mockedNumber = 123;
+      const mockedNodeId = "fake_ID";
+      const context = isMonorepo
+        ? { ...mockedContextInMonorepo, nextRelease }
+        : { ...mockedContext, nextRelease };
+      vi.mocked(mockedFetch).mockResolvedValue({
+        status: 201,
+        statusText: "Created",
+        json: () => Promise.resolve({ number: mockedNumber, node_id: mockedNodeId })
+      });
+      const returnedReference = await createPullRequest(
+        mockedHeadBranch,
+        { ...mockedMergeOptions, autoMergeAllowed: isAutoMerge },
+        context
+      );
+      expect(mockedFetch).toHaveBeenCalledWith(mockedUriForPullRequests, {
+        method: "POST",
+        headers: {
+          Accept: GITHUB_API_ACCEPT_HEADER,
+          Authorization: `Bearer ${mockedIssuePRToken}`,
+          "Content-Type": "application/json",
+          "X-GitHub-Api-Version": GITHUB_API_VERSION
+        },
+        body: JSON.stringify({
+          title: expectedTitle,
+          head: mockedHeadBranch,
+          base: context.branch,
+          body: expectedBody
+        })
+      });
+      expect(mockedLogger.logSuccess).toHaveBeenCalledWith(
+        "Created the pull request successfully."
+      );
+      assert.deepEqual(returnedReference, {
+        pullRequestNumber: mockedNumber,
+        pullRequestId: mockedNodeId
+      });
     });
-  });
-});
+  }
+);

--- a/packages/github/test/enable-auto-merge.test.ts
+++ b/packages/github/test/enable-auto-merge.test.ts
@@ -109,39 +109,39 @@ it("should not fetch the GitHub GraphQL API if no commmits are provided", async 
   );
   expect(mockedFetch).not.toHaveBeenCalled();
 });
-it.each(
-  mockedAutoMergeEnablings
-)("should enable the auto-merge with the appropriate method", async ({
-  pullRequestReference,
-  mergeOptions,
-  expectedMergeMethod,
-  expectedCommitHeadline,
-  expectedCommitBody
-}) => {
-  vi.mocked(mockedFetch).mockResolvedValue({
-    json: () =>
-      Promise.resolve({
-        data: {
-          enablePullRequestAutoMerge: {
-            pullRequest: {
-              number: pullRequestReference.pullRequestNumber,
-              autoMergeRequest: {
-                mergeMethod: expectedMergeMethod
+it.each(mockedAutoMergeEnablings)(
+  "should enable the auto-merge with the appropriate method",
+  async ({
+    pullRequestReference,
+    mergeOptions,
+    expectedMergeMethod,
+    expectedCommitHeadline,
+    expectedCommitBody
+  }) => {
+    vi.mocked(mockedFetch).mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          data: {
+            enablePullRequestAutoMerge: {
+              pullRequest: {
+                number: pullRequestReference.pullRequestNumber,
+                autoMergeRequest: {
+                  mergeMethod: expectedMergeMethod
+                }
               }
             }
           }
-        }
-      })
-  });
-  await enableAutoMerge(pullRequestReference, mergeOptions, mockedContext);
-  expect(mockedFetch).toHaveBeenCalledWith(GITHUB_GRAPHQL_API_ENDPOINT, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${mockedIssuePRToken}`,
-      "Content-Type": "application/json"
-    },
-    body: JSON.stringify({
-      query: `
+        })
+    });
+    await enableAutoMerge(pullRequestReference, mergeOptions, mockedContext);
+    expect(mockedFetch).toHaveBeenCalledWith(GITHUB_GRAPHQL_API_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${mockedIssuePRToken}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        query: `
 mutation EnablePullRequestAutoMerge(
   $pullRequestId: ID!,
   $mergeMethod: PullRequestMergeMethod!,
@@ -162,51 +162,52 @@ mutation EnablePullRequestAutoMerge(
   }
 }
 `,
-      variables: {
-        pullRequestId: mockedNodeId,
-        mergeMethod: expectedMergeMethod,
-        commitHeadline: expectedCommitHeadline,
-        commitBody: expectedCommitBody
-      }
-    })
-  });
-  expect(mockedLogger.logInfo).toHaveBeenCalledWith(
-    `Enabled the auto-merge for the pull request with the ${expectedMergeMethod} method.`
-  );
-});
-it.each(
-  mockedAutoMergeEnablingsInMonorepo
-)("should enable the auto-merge with the appropriate method in monorepo", async ({
-  pullRequestReference,
-  mergeOptions,
-  expectedMergeMethod,
-  expectedCommitHeadline,
-  expectedCommitBody
-}) => {
-  vi.mocked(mockedFetch).mockResolvedValue({
-    json: () =>
-      Promise.resolve({
-        data: {
-          enablePullRequestAutoMerge: {
-            pullRequest: {
-              number: pullRequestReference.pullRequestNumber,
-              autoMergeRequest: {
-                mergeMethod: expectedMergeMethod
+        variables: {
+          pullRequestId: mockedNodeId,
+          mergeMethod: expectedMergeMethod,
+          commitHeadline: expectedCommitHeadline,
+          commitBody: expectedCommitBody
+        }
+      })
+    });
+    expect(mockedLogger.logInfo).toHaveBeenCalledWith(
+      `Enabled the auto-merge for the pull request with the ${expectedMergeMethod} method.`
+    );
+  }
+);
+it.each(mockedAutoMergeEnablingsInMonorepo)(
+  "should enable the auto-merge with the appropriate method in monorepo",
+  async ({
+    pullRequestReference,
+    mergeOptions,
+    expectedMergeMethod,
+    expectedCommitHeadline,
+    expectedCommitBody
+  }) => {
+    vi.mocked(mockedFetch).mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          data: {
+            enablePullRequestAutoMerge: {
+              pullRequest: {
+                number: pullRequestReference.pullRequestNumber,
+                autoMergeRequest: {
+                  mergeMethod: expectedMergeMethod
+                }
               }
             }
           }
-        }
-      })
-  });
-  await enableAutoMerge(pullRequestReference, mergeOptions, mockedContextInMonorepo);
-  expect(mockedFetch).toHaveBeenCalledWith(GITHUB_GRAPHQL_API_ENDPOINT, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${mockedIssuePRToken}`,
-      "Content-Type": "application/json"
-    },
-    body: JSON.stringify({
-      query: `
+        })
+    });
+    await enableAutoMerge(pullRequestReference, mergeOptions, mockedContextInMonorepo);
+    expect(mockedFetch).toHaveBeenCalledWith(GITHUB_GRAPHQL_API_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${mockedIssuePRToken}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        query: `
 mutation EnablePullRequestAutoMerge(
   $pullRequestId: ID!,
   $mergeMethod: PullRequestMergeMethod!,
@@ -227,15 +228,16 @@ mutation EnablePullRequestAutoMerge(
   }
 }
 `,
-      variables: {
-        pullRequestId: mockedNodeId,
-        mergeMethod: expectedMergeMethod,
-        commitHeadline: expectedCommitHeadline,
-        commitBody: expectedCommitBody
-      }
-    })
-  });
-  expect(mockedLogger.logInfo).toHaveBeenCalledWith(
-    `Enabled the auto-merge for the pull request with the ${expectedMergeMethod} method.`
-  );
-});
+        variables: {
+          pullRequestId: mockedNodeId,
+          mergeMethod: expectedMergeMethod,
+          commitHeadline: expectedCommitHeadline,
+          commitBody: expectedCommitBody
+        }
+      })
+    });
+    expect(mockedLogger.logInfo).toHaveBeenCalledWith(
+      `Enabled the auto-merge for the pull request with the ${expectedMergeMethod} method.`
+    );
+  }
+);

--- a/packages/github/test/merge-references-by-number.test.ts
+++ b/packages/github/test/merge-references-by-number.test.ts
@@ -61,9 +61,9 @@ const mockedArraysWithObjectsToMerge = [
   }
 ];
 
-it.each(mockedArraysWithObjectsToMerge)("should return $expected from $input", ({
-  input,
-  expected
-}) => {
-  assert.deepEqual(mergeReferencesByNumber(input), expected);
-});
+it.each(mockedArraysWithObjectsToMerge)(
+  "should return $expected from $input",
+  ({ input, expected }) => {
+    assert.deepEqual(mergeReferencesByNumber(input), expected);
+  }
+);

--- a/packages/github/test/post-fail-comment.test.ts
+++ b/packages/github/test/post-fail-comment.test.ts
@@ -41,90 +41,87 @@ vi.mocked(getRepositoryRelatedEndpoint).mockReturnValue(
 );
 vi.mocked(getIssueAndPullRequestToken).mockReturnValue(mockedIssuePRToken);
 
-describe.each(mockedFailComments)("for $type and reference $reference", ({
-  type,
-  isMonorepo,
-  reference,
-  errors,
-  expectedBody
-}) => {
-  it("should throw an error if no branch is defined", async () => {
-    const expectedError = new Error(
-      "Failed to post the fail comment: The target branch is not defined.",
-      {
-        cause: {
-          title: "Failed to post the fail comment",
-          message: "The target branch is not defined.",
-          details: {
-            output: "targetBranch: undefined"
+describe.each(mockedFailComments)(
+  "for $type and reference $reference",
+  ({ type, isMonorepo, reference, errors, expectedBody }) => {
+    it("should throw an error if no branch is defined", async () => {
+      const expectedError = new Error(
+        "Failed to post the fail comment: The target branch is not defined.",
+        {
+          cause: {
+            title: "Failed to post the fail comment",
+            message: "The target branch is not defined.",
+            details: {
+              output: "targetBranch: undefined"
+            }
           }
         }
-      }
-    );
-    vi.mocked(formatDetailedError).mockReturnValue(expectedError);
-    await expect(postFailComment(reference, mockedContextWithoutBranch)).rejects.toThrow(
-      "The target branch is not defined."
-    );
-  });
-  it("should throw an error when the request fails", async () => {
-    vi.mocked(mockedFetch).mockRejectedValue(new Error("Failed to request the URI."));
-    await expect(postFailComment(reference, mockedContextWithNextRelease)).rejects.toThrow(
-      "Failed to request the URI."
-    );
-  });
-  it.each(mockedFailureFetches)("$title", async ({ response, expectedError }) => {
-    vi.mocked(mockedFetch).mockResolvedValue({
-      ...response,
-      json: () => Promise.resolve({ message: response.statusText })
+      );
+      vi.mocked(formatDetailedError).mockReturnValue(expectedError);
+      await expect(postFailComment(reference, mockedContextWithoutBranch)).rejects.toThrow(
+        "The target branch is not defined."
+      );
     });
-    vi.mocked(formatDetailedError).mockReturnValue(expectedError);
-    await expect(postFailComment(reference, mockedContextWithNextRelease)).rejects.toThrow(
-      expectedError
-    );
-    expect(mockedLogger.logError).toHaveBeenCalledWith(
-      `Failed to post the fail comment on ${type} #${reference.number}.`
-    );
-    expect(process.exitCode).toBe(response.status);
-  });
-  it("should log a warning message if the URI is not found", async () => {
-    const context = isMonorepo
-      ? { ...mockedContextWithNextReleaseInMonorepo, errors }
-      : { ...mockedContextWithNextRelease, errors };
-    vi.mocked(checkErrorType).mockImplementation(error =>
-      error instanceof Error ? error.message : String(error)
-    );
-    vi.mocked(mockedFetch).mockResolvedValue({
-      status: 404,
-      statusText: "Not Found",
-      json: () => Promise.resolve({ message: "Not Found" })
+    it("should throw an error when the request fails", async () => {
+      vi.mocked(mockedFetch).mockRejectedValue(new Error("Failed to request the URI."));
+      await expect(postFailComment(reference, mockedContextWithNextRelease)).rejects.toThrow(
+        "Failed to request the URI."
+      );
     });
-    await postFailComment(reference, context);
-    expect(mockedLogger.logWarn).toHaveBeenCalledWith(
-      `The resource requested for ${type} #123 has not been found; therefore, the fail comment has not been added.`
-    );
-  });
-  it("should post a fail comment", async () => {
-    const context = isMonorepo
-      ? { ...mockedContextWithNextReleaseInMonorepo, errors }
-      : { ...mockedContextWithNextRelease, errors };
-    vi.mocked(mockedFetch).mockResolvedValue({
-      status: 201,
-      statusText: "Created",
-      json: () => Promise.resolve({ message: "Created" })
+    it.each(mockedFailureFetches)("$title", async ({ response, expectedError }) => {
+      vi.mocked(mockedFetch).mockResolvedValue({
+        ...response,
+        json: () => Promise.resolve({ message: response.statusText })
+      });
+      vi.mocked(formatDetailedError).mockReturnValue(expectedError);
+      await expect(postFailComment(reference, mockedContextWithNextRelease)).rejects.toThrow(
+        expectedError
+      );
+      expect(mockedLogger.logError).toHaveBeenCalledWith(
+        `Failed to post the fail comment on ${type} #${reference.number}.`
+      );
+      expect(process.exitCode).toBe(response.status);
     });
-    await postFailComment(reference, context);
-    expect(mockedFetch).toHaveBeenCalledWith(mockedUriForComments, {
-      method: "POST",
-      headers: {
-        Accept: GITHUB_API_ACCEPT_HEADER,
-        Authorization: `Bearer ${mockedIssuePRToken}`,
-        "Content-Type": "application/json",
-        "X-GitHub-Api-Version": GITHUB_API_VERSION
-      },
-      body: JSON.stringify({
-        body: expectedBody
-      })
+    it("should log a warning message if the URI is not found", async () => {
+      const context = isMonorepo
+        ? { ...mockedContextWithNextReleaseInMonorepo, errors }
+        : { ...mockedContextWithNextRelease, errors };
+      vi.mocked(checkErrorType).mockImplementation(error =>
+        error instanceof Error ? error.message : String(error)
+      );
+      vi.mocked(mockedFetch).mockResolvedValue({
+        status: 404,
+        statusText: "Not Found",
+        json: () => Promise.resolve({ message: "Not Found" })
+      });
+      await postFailComment(reference, context);
+      expect(mockedLogger.logWarn).toHaveBeenCalledWith(
+        `The resource requested for ${type} #123 has not been found; therefore, the fail comment has not been added.`
+      );
     });
-    expect(mockedLogger.logInfo).toHaveBeenCalledWith(`Added fail comment on ${type} #123.`);
-  });
-});
+    it("should post a fail comment", async () => {
+      const context = isMonorepo
+        ? { ...mockedContextWithNextReleaseInMonorepo, errors }
+        : { ...mockedContextWithNextRelease, errors };
+      vi.mocked(mockedFetch).mockResolvedValue({
+        status: 201,
+        statusText: "Created",
+        json: () => Promise.resolve({ message: "Created" })
+      });
+      await postFailComment(reference, context);
+      expect(mockedFetch).toHaveBeenCalledWith(mockedUriForComments, {
+        method: "POST",
+        headers: {
+          Accept: GITHUB_API_ACCEPT_HEADER,
+          Authorization: `Bearer ${mockedIssuePRToken}`,
+          "Content-Type": "application/json",
+          "X-GitHub-Api-Version": GITHUB_API_VERSION
+        },
+        body: JSON.stringify({
+          body: expectedBody
+        })
+      });
+      expect(mockedLogger.logInfo).toHaveBeenCalledWith(`Added fail comment on ${type} #123.`);
+    });
+  }
+);

--- a/packages/github/test/post-success-comment.test.ts
+++ b/packages/github/test/post-success-comment.test.ts
@@ -41,85 +41,84 @@ vi.mocked(getRepositoryRelatedEndpoint).mockReturnValue(
 );
 vi.mocked(getIssueAndPullRequestToken).mockReturnValue(mockedIssuePRToken);
 
-describe.each(mockedSuccessComments)("for $type and reference $reference", ({
-  type,
-  isMonorepo,
-  reference,
-  releaseInfos,
-  expectedBody
-}) => {
-  it("should throw an error if no next release is defined", async () => {
-    const expectedError = new Error(
-      "Failed to post the success comment: The next release is not defined.",
-      {
-        cause: {
-          title: "Failed to post the success comment",
-          message: "The next release is not defined.",
-          details: {
-            output: "nextRelease: undefined"
+describe.each(mockedSuccessComments)(
+  "for $type and reference $reference",
+  ({ type, isMonorepo, reference, releaseInfos, expectedBody }) => {
+    it("should throw an error if no next release is defined", async () => {
+      const expectedError = new Error(
+        "Failed to post the success comment: The next release is not defined.",
+        {
+          cause: {
+            title: "Failed to post the success comment",
+            message: "The next release is not defined.",
+            details: {
+              output: "nextRelease: undefined"
+            }
           }
         }
-      }
-    );
-    vi.mocked(formatDetailedError).mockReturnValue(expectedError);
-    await expect(postSuccessComment(reference, mockedContext)).rejects.toThrow(expectedError);
-  });
-  it("should throw an error when the request fails", async () => {
-    vi.mocked(mockedFetch).mockRejectedValue(new Error("Failed to request the URI."));
-    await expect(postSuccessComment(reference, mockedContextWithNextRelease)).rejects.toThrow(
-      "Failed to request the URI."
-    );
-  });
-  it.each(mockedFailureFetches)("$title", async ({ response, expectedError }) => {
-    vi.mocked(mockedFetch).mockResolvedValue({
-      ...response,
-      json: () => Promise.resolve({ message: response.statusText })
+      );
+      vi.mocked(formatDetailedError).mockReturnValue(expectedError);
+      await expect(postSuccessComment(reference, mockedContext)).rejects.toThrow(expectedError);
     });
-    vi.mocked(formatDetailedError).mockReturnValue(expectedError);
-    await expect(postSuccessComment(reference, mockedContextWithNextRelease)).rejects.toThrow(
-      expectedError
-    );
-    expect(mockedLogger.logError).toHaveBeenCalledWith(
-      `Failed to post the success comment on ${type} #${reference.number}.`
-    );
-    expect(process.exitCode).toBe(response.status);
-  });
-  it("should log a warning message if the URI is not found", async () => {
-    const context = isMonorepo
-      ? { ...mockedContextWithNextReleaseInMonorepo, releaseInfos }
-      : { ...mockedContextWithNextRelease, releaseInfos };
-    vi.mocked(mockedFetch).mockResolvedValue({
-      status: 404,
-      statusText: "Not Found",
-      json: () => Promise.resolve({ message: "Not Found" })
+    it("should throw an error when the request fails", async () => {
+      vi.mocked(mockedFetch).mockRejectedValue(new Error("Failed to request the URI."));
+      await expect(postSuccessComment(reference, mockedContextWithNextRelease)).rejects.toThrow(
+        "Failed to request the URI."
+      );
     });
-    await postSuccessComment(reference, context);
-    expect(mockedLogger.logWarn).toHaveBeenCalledWith(
-      `The resource requested for ${type} #123 has not been found; therefore, the success comment has not been added.`
-    );
-  });
-  it("should post a success comment", async () => {
-    const context = isMonorepo
-      ? { ...mockedContextWithNextReleaseInMonorepo, releaseInfos }
-      : { ...mockedContextWithNextRelease, releaseInfos };
-    vi.mocked(mockedFetch).mockResolvedValue({
-      status: 201,
-      statusText: "Created",
-      json: () => Promise.resolve({ message: "Created" })
+    it.each(mockedFailureFetches)("$title", async ({ response, expectedError }) => {
+      vi.mocked(mockedFetch).mockResolvedValue({
+        ...response,
+        json: () => Promise.resolve({ message: response.statusText })
+      });
+      vi.mocked(formatDetailedError).mockReturnValue(expectedError);
+      await expect(postSuccessComment(reference, mockedContextWithNextRelease)).rejects.toThrow(
+        expectedError
+      );
+      expect(mockedLogger.logError).toHaveBeenCalledWith(
+        `Failed to post the success comment on ${type} #${reference.number}.`
+      );
+      expect(process.exitCode).toBe(response.status);
     });
-    await postSuccessComment(reference, context);
-    expect(mockedFetch).toHaveBeenCalledWith(mockedUriForComments, {
-      method: "POST",
-      headers: {
-        Accept: GITHUB_API_ACCEPT_HEADER,
-        Authorization: `Bearer ${mockedIssuePRToken}`,
-        "Content-Type": "application/json",
-        "X-GitHub-Api-Version": GITHUB_API_VERSION
-      },
-      body: JSON.stringify({
-        body: expectedBody
-      })
+    it("should log a warning message if the URI is not found", async () => {
+      const context = isMonorepo
+        ? { ...mockedContextWithNextReleaseInMonorepo, releaseInfos }
+        : { ...mockedContextWithNextRelease, releaseInfos };
+      vi.mocked(mockedFetch).mockResolvedValue({
+        status: 404,
+        statusText: "Not Found",
+        json: () => Promise.resolve({ message: "Not Found" })
+      });
+      await postSuccessComment(reference, context);
+      expect(mockedLogger.logWarn).toHaveBeenCalledWith(
+        `The resource requested for ${type} #123 has not been found; therefore, the success comment has not been added.`
+      );
     });
-    expect(mockedLogger.logSuccess).toHaveBeenCalledWith(`Added success comment on ${type} #123.`);
-  });
-});
+    it("should post a success comment", async () => {
+      const context = isMonorepo
+        ? { ...mockedContextWithNextReleaseInMonorepo, releaseInfos }
+        : { ...mockedContextWithNextRelease, releaseInfos };
+      vi.mocked(mockedFetch).mockResolvedValue({
+        status: 201,
+        statusText: "Created",
+        json: () => Promise.resolve({ message: "Created" })
+      });
+      await postSuccessComment(reference, context);
+      expect(mockedFetch).toHaveBeenCalledWith(mockedUriForComments, {
+        method: "POST",
+        headers: {
+          Accept: GITHUB_API_ACCEPT_HEADER,
+          Authorization: `Bearer ${mockedIssuePRToken}`,
+          "Content-Type": "application/json",
+          "X-GitHub-Api-Version": GITHUB_API_VERSION
+        },
+        body: JSON.stringify({
+          body: expectedBody
+        })
+      });
+      expect(mockedLogger.logSuccess).toHaveBeenCalledWith(
+        `Added success comment on ${type} #123.`
+      );
+    });
+  }
+);

--- a/packages/github/test/tag-pull-request-and-issue.test.ts
+++ b/packages/github/test/tag-pull-request-and-issue.test.ts
@@ -55,75 +55,70 @@ it("should throw an error if `nextRelease` is not defined", async () => {
     )
   ).rejects.toThrow(expectedError);
 });
-describe.each(
-  mockedPullRequestsAndIssuesToTag
-)("for $type #$reference.number with Git tags $reference.gitTags", async ({
-  isMonorepo,
-  type,
-  reference,
-  nextRelease,
-  expectedLabels
-}) => {
-  const context = isMonorepo
-    ? { ...mockedContextInMonorepo, nextRelease }
-    : { ...mockedContext, nextRelease };
-  it.each(mockedFailureFetches)("$title", async ({ response, expectedError }) => {
-    vi.mocked(getIssueAndPullRequestToken).mockReturnValue(mockedIssuePRToken);
-    vi.mocked(getRepositoryRelatedEndpoint).mockReturnValue(mockedUri);
-    vi.mocked(mockedFetch).mockResolvedValue({
-      ...response,
-      json: () => Promise.resolve({ message: response.statusText })
+describe.each(mockedPullRequestsAndIssuesToTag)(
+  "for $type #$reference.number with Git tags $reference.gitTags",
+  async ({ isMonorepo, type, reference, nextRelease, expectedLabels }) => {
+    const context = isMonorepo
+      ? { ...mockedContextInMonorepo, nextRelease }
+      : { ...mockedContext, nextRelease };
+    it.each(mockedFailureFetches)("$title", async ({ response, expectedError }) => {
+      vi.mocked(getIssueAndPullRequestToken).mockReturnValue(mockedIssuePRToken);
+      vi.mocked(getRepositoryRelatedEndpoint).mockReturnValue(mockedUri);
+      vi.mocked(mockedFetch).mockResolvedValue({
+        ...response,
+        json: () => Promise.resolve({ message: response.statusText })
+      });
+      vi.mocked(formatDetailedError).mockReturnValue(expectedError);
+      await expect(tagPullRequestAndIssue(reference, context)).rejects.toThrow(expectedError);
+      expect(nextRelease.length).toBeGreaterThan(0);
+      expect(mockedLogger.logError).toHaveBeenCalledWith(
+        `Failed to tag ${type} #${mockedIssueNumber}.`
+      );
+      expect(process.exitCode).toBe(response.status);
     });
-    vi.mocked(formatDetailedError).mockReturnValue(expectedError);
-    await expect(tagPullRequestAndIssue(reference, context)).rejects.toThrow(expectedError);
-    expect(nextRelease.length).toBeGreaterThan(0);
-    expect(mockedLogger.logError).toHaveBeenCalledWith(
-      `Failed to tag ${type} #${mockedIssueNumber}.`
-    );
-    expect(process.exitCode).toBe(response.status);
-  });
-  it("should log a warning message if the URI is not found", async () => {
-    vi.mocked(mockedFetch).mockResolvedValue({
-      status: 404,
-      statusText: "Not Found",
-      json: () => Promise.resolve({ message: "Not Found" })
+    it("should log a warning message if the URI is not found", async () => {
+      vi.mocked(mockedFetch).mockResolvedValue({
+        status: 404,
+        statusText: "Not Found",
+        json: () => Promise.resolve({ message: "Not Found" })
+      });
+      await tagPullRequestAndIssue(reference, context);
+      expect(mockedLogger.logWarn).toHaveBeenCalledWith(
+        `The resource requested for ${type} #${mockedIssueNumber} has not been found; therefore, no labels have been added.`
+      );
     });
-    await tagPullRequestAndIssue(reference, context);
-    expect(mockedLogger.logWarn).toHaveBeenCalledWith(
-      `The resource requested for ${type} #${mockedIssueNumber} has not been found; therefore, no labels have been added.`
-    );
-  });
-  it(`should tag the ${type}`, async () => {
-    const expectedLabelEnumeration = new Intl.ListFormat("en-GB", {
-      style: "long",
-      type: "conjunction"
-    }).format(expectedLabels.map(label => `\`${label}\``));
-    const expectedLabelsDisplay =
-      expectedLabels.length > 1
-        ? `labels ${expectedLabelEnumeration}`
-        : `label \`${[expectedLabels]}\``;
-    const expectedLabelMessage = expectedLabels.length ? ` with ${expectedLabelsDisplay}` : "";
-    vi.mocked(agreeInNumber).mockReturnValue(expectedLabels.length > 1 ? "labels" : "label");
-    vi.mocked(mockedFetch).mockResolvedValue({
-      status: 200,
-      statusText: "OK",
-      json: () => Promise.resolve({ message: "OK" })
+    it(`should tag the ${type}`, async () => {
+      const expectedLabelEnumeration = new Intl.ListFormat("en-GB", {
+        style: "long",
+        type: "conjunction"
+      }).format(expectedLabels.map(label => `\`${label}\``));
+      const expectedLabelsDisplay =
+        expectedLabels.length > 1
+          ? `labels ${expectedLabelEnumeration}`
+          : `label \`${[expectedLabels]}\``;
+      const expectedLabelMessage = expectedLabels.length ? ` with ${expectedLabelsDisplay}` : "";
+      vi.mocked(agreeInNumber).mockReturnValue(expectedLabels.length > 1 ? "labels" : "label");
+      vi.mocked(mockedFetch).mockResolvedValue({
+        status: 200,
+        statusText: "OK",
+        json: () => Promise.resolve({ message: "OK" })
+      });
+      await tagPullRequestAndIssue(reference, context);
+      expect(mockedFetch).toHaveBeenCalledWith(mockedUriForLabels, {
+        method: "POST",
+        headers: {
+          Accept: GITHUB_API_ACCEPT_HEADER,
+          Authorization: `Bearer ${mockedIssuePRToken}`,
+          "Content-Type": "application/json",
+          "X-GitHub-Api-Version": GITHUB_API_VERSION
+        },
+        body: JSON.stringify({
+          labels: expectedLabels
+        })
+      });
+      expect(mockedLogger.logSuccess).toHaveBeenCalledWith(
+        `Tagged ${type} #${mockedIssueNumber} successfully${expectedLabelMessage}.`
+      );
     });
-    await tagPullRequestAndIssue(reference, context);
-    expect(mockedFetch).toHaveBeenCalledWith(mockedUriForLabels, {
-      method: "POST",
-      headers: {
-        Accept: GITHUB_API_ACCEPT_HEADER,
-        Authorization: `Bearer ${mockedIssuePRToken}`,
-        "Content-Type": "application/json",
-        "X-GitHub-Api-Version": GITHUB_API_VERSION
-      },
-      body: JSON.stringify({
-        labels: expectedLabels
-      })
-    });
-    expect(mockedLogger.logSuccess).toHaveBeenCalledWith(
-      `Tagged ${type} #${mockedIssueNumber} successfully${expectedLabelMessage}.`
-    );
-  });
-});
+  }
+);

--- a/packages/logger/test/add-error-to-context.test.ts
+++ b/packages/logger/test/add-error-to-context.test.ts
@@ -6,25 +6,27 @@ import { mockedContext } from "./fixtures/mocked-context.js";
 
 vi.mock("../src/is-detailed-error.js", () => ({ isDetailedError: vi.fn() }));
 
-it.each(
-  invalidDetailedErrors
-)("should not add an error to the context if it is not an `Error` object", invalidDetailedError => {
-  vi.mocked(isDetailedError).mockReturnValue(false);
-  addErrorToContext(invalidDetailedError, mockedContext);
-  assert.notDeepNestedInclude(mockedContext.errors, invalidDetailedError);
-});
+it.each(invalidDetailedErrors)(
+  "should not add an error to the context if it is not an `Error` object",
+  invalidDetailedError => {
+    vi.mocked(isDetailedError).mockReturnValue(false);
+    addErrorToContext(invalidDetailedError, mockedContext);
+    assert.notDeepNestedInclude(mockedContext.errors, invalidDetailedError);
+  }
+);
 it("should not add an error to the context if it is an `Error` object without `cause` property", () => {
   vi.mocked(isDetailedError).mockReturnValue(false);
   addErrorToContext(new Error("Error"), mockedContext);
   assert.notDeepNestedInclude(mockedContext.errors, new Error("Error"));
 });
-it.each(
-  invalidDetailedErrors
-)("should not add an error to the context if it is an `Error` object with an invalid `cause` property", invalidDetailedError => {
-  vi.mocked(isDetailedError).mockReturnValue(false);
-  addErrorToContext(new Error("Error", { cause: invalidDetailedError }), mockedContext);
-  assert.notDeepNestedInclude(mockedContext.errors, invalidDetailedError);
-});
+it.each(invalidDetailedErrors)(
+  "should not add an error to the context if it is an `Error` object with an invalid `cause` property",
+  invalidDetailedError => {
+    vi.mocked(isDetailedError).mockReturnValue(false);
+    addErrorToContext(new Error("Error", { cause: invalidDetailedError }), mockedContext);
+    assert.notDeepNestedInclude(mockedContext.errors, invalidDetailedError);
+  }
+);
 it.each(validDetailedErrors)("should add an error to the context", validDetailedError => {
   vi.mocked(isDetailedError).mockReturnValue(true);
   addErrorToContext(new Error("Error", { cause: validDetailedError }), mockedContext);

--- a/packages/logger/test/format-message.test.ts
+++ b/packages/logger/test/format-message.test.ts
@@ -30,16 +30,13 @@ it("should format debug message", () => {
   );
 });
 
-it.each(
-  messageTypes
-)("should format $message of type $type with $symbol when debug mode is deactivated", ({
-  type,
-  message,
-  symbol
-}) => {
-  const mockedLoggerContext = { isDebug: false, type: type } as LoggerContext;
-  vi.mocked(setPrefix).mockReturnValue(expectedPrefix);
-  expect(formatMessage(message, mockedLoggerContext)).toBe(
-    `${expectedPrefix} ${symbol} ${message}`
-  );
-});
+it.each(messageTypes)(
+  "should format $message of type $type with $symbol when debug mode is deactivated",
+  ({ type, message, symbol }) => {
+    const mockedLoggerContext = { isDebug: false, type: type } as LoggerContext;
+    vi.mocked(setPrefix).mockReturnValue(expectedPrefix);
+    expect(formatMessage(message, mockedLoggerContext)).toBe(
+      `${expectedPrefix} ${symbol} ${message}`
+    );
+  }
+);

--- a/packages/logger/test/is-detailed-error.test.ts
+++ b/packages/logger/test/is-detailed-error.test.ts
@@ -3,13 +3,15 @@ import { expect, it } from "vitest";
 import { isDetailedError } from "../src/index.js";
 import { invalidDetailedErrors, validDetailedErrors } from "./fixtures/detailed-errors.js";
 
-it.each(
-  invalidDetailedErrors
-)("should return `false` if this is not a detailed error", invalidDetailedError => {
-  expect(isDetailedError(invalidDetailedError)).toBe(false);
-});
-it.each(
-  validDetailedErrors
-)("should return `true` if this is a detailed error", validDetailedError => {
-  expect(isDetailedError(validDetailedError)).toBe(true);
-});
+it.each(invalidDetailedErrors)(
+  "should return `false` if this is not a detailed error",
+  invalidDetailedError => {
+    expect(isDetailedError(invalidDetailedError)).toBe(false);
+  }
+);
+it.each(validDetailedErrors)(
+  "should return `true` if this is a detailed error",
+  validDetailedError => {
+    expect(isDetailedError(validDetailedError)).toBe(true);
+  }
+);

--- a/packages/logger/test/set-prefix.test.ts
+++ b/packages/logger/test/set-prefix.test.ts
@@ -29,33 +29,33 @@ const mockedLoggerContextNotForDebugModeWithoutScope: LoggerContext = {
   type: "info"
 };
 
-describe.each(times)("timestamp at $mockedTimestamp ($expectedTime UTC)", ({
-  mockedTimestamp,
-  expectedTime
-}) => {
-  it("should return the appropriate prefix when debug mode is activated", () => {
-    expect(setPrefix(mockedTimestamp, mockedLoggerContextForDebugMode)).toBe(
-      `\x1b[1;34m[debug] ${WORKSPACE_NAME}:my-scope\x1b[0m`
-    );
-  });
-  it("should return the appropriate prefix when debug mode is activated and there is no scope", () => {
-    expect(setPrefix(mockedTimestamp, mockedLoggerContextForDebugModeWithoutScope)).toBe(
-      `\x1b[1;34m[debug] ${WORKSPACE_NAME}\x1b[0m`
-    );
-  });
-  it("should return the appropriate prefix when debug mode is activated and there is no debug scope", () => {
-    expect(setPrefix(mockedTimestamp, mockedLoggerContextForDebugModeWithoutDebugScope)).toBe(
-      `[${expectedTime}] [${WORKSPACE_NAME}] [@${WORKSPACE_NAME}/my-scope] \u203a`
-    );
-  });
-  it("should return the appropriate prefix when debug mode is deactivated", () => {
-    expect(setPrefix(mockedTimestamp, mockedLoggerContextNotForDebugMode)).toBe(
-      `[${expectedTime}] [${WORKSPACE_NAME}] [@${WORKSPACE_NAME}/my-scope] \u203a`
-    );
-  });
-  it("should return the appropriate prefix when debug mode is deactivated and there is no scope", () => {
-    expect(setPrefix(mockedTimestamp, mockedLoggerContextNotForDebugModeWithoutScope)).toBe(
-      `[${expectedTime}] [${WORKSPACE_NAME}] \u203a`
-    );
-  });
-});
+describe.each(times)(
+  "timestamp at $mockedTimestamp ($expectedTime UTC)",
+  ({ mockedTimestamp, expectedTime }) => {
+    it("should return the appropriate prefix when debug mode is activated", () => {
+      expect(setPrefix(mockedTimestamp, mockedLoggerContextForDebugMode)).toBe(
+        `\x1b[1;34m[debug] ${WORKSPACE_NAME}:my-scope\x1b[0m`
+      );
+    });
+    it("should return the appropriate prefix when debug mode is activated and there is no scope", () => {
+      expect(setPrefix(mockedTimestamp, mockedLoggerContextForDebugModeWithoutScope)).toBe(
+        `\x1b[1;34m[debug] ${WORKSPACE_NAME}\x1b[0m`
+      );
+    });
+    it("should return the appropriate prefix when debug mode is activated and there is no debug scope", () => {
+      expect(setPrefix(mockedTimestamp, mockedLoggerContextForDebugModeWithoutDebugScope)).toBe(
+        `[${expectedTime}] [${WORKSPACE_NAME}] [@${WORKSPACE_NAME}/my-scope] \u203a`
+      );
+    });
+    it("should return the appropriate prefix when debug mode is deactivated", () => {
+      expect(setPrefix(mockedTimestamp, mockedLoggerContextNotForDebugMode)).toBe(
+        `[${expectedTime}] [${WORKSPACE_NAME}] [@${WORKSPACE_NAME}/my-scope] \u203a`
+      );
+    });
+    it("should return the appropriate prefix when debug mode is deactivated and there is no scope", () => {
+      expect(setPrefix(mockedTimestamp, mockedLoggerContextNotForDebugModeWithoutScope)).toBe(
+        `[${expectedTime}] [${WORKSPACE_NAME}] \u203a`
+      );
+    });
+  }
+);

--- a/packages/npm/test/prepare-publishing.test.ts
+++ b/packages/npm/test/prepare-publishing.test.ts
@@ -98,40 +98,39 @@ describe.each(mockedNextReleases)("for package $name and version $version", next
       `The ${nextRelease.name || "root"} package is private; therefore, the release will not be published.`
     );
   });
-  describe.each(packageManagers)("for package manager $packageManager", ({
-    packageManager,
-    args,
-    noGitChecks
-  }) => {
-    const { name, pathname, version, npmTag } = nextRelease;
-    const expectedArgs = noGitChecks
-      ? npmTag
-        ? [...args, "--tag", npmTag, noGitChecks]
-        : [...args, noGitChecks]
-      : npmTag
-        ? [...args, "--tag", npmTag]
-        : args;
-    it("should prepare the publishing with the expected values", async () => {
-      const context: Context = {
-        ...mockedContext,
-        nextRelease: [nextRelease],
-        authToken: {
-          fileExists: true,
-          authTokenExists: true
-        }
-      };
-      const expectedPackagePublishing: PackagePublishing = {
-        name: name,
-        packageManifestName: packageManifestContent.name,
-        pathname,
-        version,
-        packageManager,
-        args: expectedArgs
-      };
-      if (npmTag) expectedPackagePublishing.npmTag = npmTag;
-      vi.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify(packageManifestContent));
-      vi.mocked(getPackageManager).mockReturnValue(packageManager);
-      assert.deepEqual(await preparePublishing(nextRelease, context), expectedPackagePublishing);
-    });
-  });
+  describe.each(packageManagers)(
+    "for package manager $packageManager",
+    ({ packageManager, args, noGitChecks }) => {
+      const { name, pathname, version, npmTag } = nextRelease;
+      const expectedArgs = noGitChecks
+        ? npmTag
+          ? [...args, "--tag", npmTag, noGitChecks]
+          : [...args, noGitChecks]
+        : npmTag
+          ? [...args, "--tag", npmTag]
+          : args;
+      it("should prepare the publishing with the expected values", async () => {
+        const context: Context = {
+          ...mockedContext,
+          nextRelease: [nextRelease],
+          authToken: {
+            fileExists: true,
+            authTokenExists: true
+          }
+        };
+        const expectedPackagePublishing: PackagePublishing = {
+          name: name,
+          packageManifestName: packageManifestContent.name,
+          pathname,
+          version,
+          packageManager,
+          args: expectedArgs
+        };
+        if (npmTag) expectedPackagePublishing.npmTag = npmTag;
+        vi.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify(packageManifestContent));
+        vi.mocked(getPackageManager).mockReturnValue(packageManager);
+        assert.deepEqual(await preparePublishing(nextRelease, context), expectedPackagePublishing);
+      });
+    }
+  );
 });

--- a/packages/npm/test/publish-to-registry.test.ts
+++ b/packages/npm/test/publish-to-registry.test.ts
@@ -43,118 +43,119 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe.each(
-  mockedPackagePublishingSet
-)("for package $name and version $version", packagePublishing => {
-  const { name, packageManifestName, pathname, version, packageManager, args, npmTag } =
-    packagePublishing;
-  const packageName = name || "root";
-  const mockedCwd = pathname === "." ? mockedContext.cwd : `${mockedContext.cwd}/${pathname}`;
-  const mockedOptions = {
-    cwd: mockedCwd,
-    env: mockedContext.env
-  };
-  it("should throw an error if the auth token is not defined", async () => {
-    const expectedError = new Error(
-      "Failed to publish to the NPM registry: The auth token context could not be loaded.",
-      {
-        cause: {
-          title: "Failed to publish to the NPM registry",
-          message: "The auth token context could not be loaded.",
-          details: {
-            output: "authToken: undefined"
+describe.each(mockedPackagePublishingSet)(
+  "for package $name and version $version",
+  packagePublishing => {
+    const { name, packageManifestName, pathname, version, packageManager, args, npmTag } =
+      packagePublishing;
+    const packageName = name || "root";
+    const mockedCwd = pathname === "." ? mockedContext.cwd : `${mockedContext.cwd}/${pathname}`;
+    const mockedOptions = {
+      cwd: mockedCwd,
+      env: mockedContext.env
+    };
+    it("should throw an error if the auth token is not defined", async () => {
+      const expectedError = new Error(
+        "Failed to publish to the NPM registry: The auth token context could not be loaded.",
+        {
+          cause: {
+            title: "Failed to publish to the NPM registry",
+            message: "The auth token context could not be loaded.",
+            details: {
+              output: "authToken: undefined"
+            }
           }
         }
-      }
-    );
-    vi.mocked(formatDetailedError).mockReturnValue(expectedError);
-    expect(publishToRegistry(packagePublishing, mockedContext)).rejects.toThrow(expectedError);
-  });
-  it("should not call `setAuthToken()` nor `removeAuthToken()` when the `.npmrc` file already exists and sets auth token", async () => {
-    vi.mocked(getNpmrcFile).mockReturnValue(mockedNpmrcFile);
-    vi.mocked(runCommand).mockResolvedValue({ status: 0, stdout: "", stderr: "" });
-    const mockedSetAuthToken = vi.mocked(setAuthToken).mockImplementation(() => undefined);
-    const mockedRemoveAuthToken = vi.mocked(removeAuthToken).mockImplementation(() => undefined);
-    await publishToRegistry(packagePublishing, mockedContextWithAuthToken);
-    expect(mockedSetAuthToken).not.toHaveBeenCalled();
-    expect(mockedRemoveAuthToken).not.toHaveBeenCalled();
-  });
-  it("should call `setAuthToken()` and `removeAuthToken()` when the `.npmrc` file does not exist", async () => {
-    vi.mocked(getNpmrcFile).mockReturnValue(null);
-    vi.mocked(runCommand).mockResolvedValue({ status: 0, stdout: "", stderr: "" });
-    const mockedSetAuthToken = vi.mocked(setAuthToken).mockImplementation(() => undefined);
-    const mockedRemoveAuthToken = vi.mocked(removeAuthToken).mockImplementation(() => undefined);
-    await publishToRegistry(packagePublishing, {
-      ...mockedContext,
-      authToken: {
-        fileExists: false,
-        authTokenExists: false
-      }
+      );
+      vi.mocked(formatDetailedError).mockReturnValue(expectedError);
+      expect(publishToRegistry(packagePublishing, mockedContext)).rejects.toThrow(expectedError);
     });
-    expect(mockedSetAuthToken).toHaveBeenCalled();
-    expect(mockedRemoveAuthToken).toHaveBeenCalled();
-  });
-  it("should call `setAuthToken()` and `removeAuthToken()` when the `.npmrc` file does not set auth token", async () => {
-    vi.mocked(getNpmrcFile).mockReturnValue(null);
-    vi.mocked(runCommand).mockResolvedValue({ status: 0, stdout: "", stderr: "" });
-    const mockedSetAuthToken = vi.mocked(setAuthToken).mockImplementation(() => undefined);
-    const mockedRemoveAuthToken = vi.mocked(removeAuthToken).mockImplementation(() => undefined);
-    await publishToRegistry(packagePublishing, {
-      ...mockedContext,
-      authToken: {
-        fileExists: true,
-        authTokenExists: false
-      }
+    it("should not call `setAuthToken()` nor `removeAuthToken()` when the `.npmrc` file already exists and sets auth token", async () => {
+      vi.mocked(getNpmrcFile).mockReturnValue(mockedNpmrcFile);
+      vi.mocked(runCommand).mockResolvedValue({ status: 0, stdout: "", stderr: "" });
+      const mockedSetAuthToken = vi.mocked(setAuthToken).mockImplementation(() => undefined);
+      const mockedRemoveAuthToken = vi.mocked(removeAuthToken).mockImplementation(() => undefined);
+      await publishToRegistry(packagePublishing, mockedContextWithAuthToken);
+      expect(mockedSetAuthToken).not.toHaveBeenCalled();
+      expect(mockedRemoveAuthToken).not.toHaveBeenCalled();
     });
-    expect(mockedSetAuthToken).toHaveBeenCalled();
-    expect(mockedRemoveAuthToken).toHaveBeenCalled();
-  });
-  it("should log an error message if the publish command fails", async () => {
-    const expectedOutput = "status: 128\n\nstdout: \n\nstderr: Some error message.";
-    const expectedError = new Error(
-      `Failed to run the \`${packageManager} publish\` command: The command failed with exit code 128.`,
-      {
-        cause: {
-          title: `Failed to run the \`${packageManager} publish\` command`,
-          message: "The command failed with exit code 128.",
-          details: {
-            output: expectedOutput,
-            command: `${packageManager} ${args.join(" ")}`
+    it("should call `setAuthToken()` and `removeAuthToken()` when the `.npmrc` file does not exist", async () => {
+      vi.mocked(getNpmrcFile).mockReturnValue(null);
+      vi.mocked(runCommand).mockResolvedValue({ status: 0, stdout: "", stderr: "" });
+      const mockedSetAuthToken = vi.mocked(setAuthToken).mockImplementation(() => undefined);
+      const mockedRemoveAuthToken = vi.mocked(removeAuthToken).mockImplementation(() => undefined);
+      await publishToRegistry(packagePublishing, {
+        ...mockedContext,
+        authToken: {
+          fileExists: false,
+          authTokenExists: false
+        }
+      });
+      expect(mockedSetAuthToken).toHaveBeenCalled();
+      expect(mockedRemoveAuthToken).toHaveBeenCalled();
+    });
+    it("should call `setAuthToken()` and `removeAuthToken()` when the `.npmrc` file does not set auth token", async () => {
+      vi.mocked(getNpmrcFile).mockReturnValue(null);
+      vi.mocked(runCommand).mockResolvedValue({ status: 0, stdout: "", stderr: "" });
+      const mockedSetAuthToken = vi.mocked(setAuthToken).mockImplementation(() => undefined);
+      const mockedRemoveAuthToken = vi.mocked(removeAuthToken).mockImplementation(() => undefined);
+      await publishToRegistry(packagePublishing, {
+        ...mockedContext,
+        authToken: {
+          fileExists: true,
+          authTokenExists: false
+        }
+      });
+      expect(mockedSetAuthToken).toHaveBeenCalled();
+      expect(mockedRemoveAuthToken).toHaveBeenCalled();
+    });
+    it("should log an error message if the publish command fails", async () => {
+      const expectedOutput = "status: 128\n\nstdout: \n\nstderr: Some error message.";
+      const expectedError = new Error(
+        `Failed to run the \`${packageManager} publish\` command: The command failed with exit code 128.`,
+        {
+          cause: {
+            title: `Failed to run the \`${packageManager} publish\` command`,
+            message: "The command failed with exit code 128.",
+            details: {
+              output: expectedOutput,
+              command: `${packageManager} ${args.join(" ")}`
+            }
           }
         }
-      }
-    );
-    const mockedCommand = vi
-      .mocked(runCommand)
-      .mockResolvedValue({ status: 128, stdout: "", stderr: "Some error message." });
-    vi.mocked(getNpmrcFile).mockReturnValue(mockedNpmrcFile);
-    vi.mocked(formatOutputFromCommandResult).mockReturnValue(expectedOutput);
-    vi.mocked(formatDetailedError).mockReturnValue(expectedError);
-    await expect(publishToRegistry(packagePublishing, mockedContextWithAuthToken)).rejects.toThrow(
-      expectedError
-    );
-    expect(mockedCommand).toHaveBeenCalledWith(packageManager, args, mockedOptions);
-    expect(mockedLogger.logError).toHaveBeenCalledWith(
-      `Failed to publish release ${version} of ${packageName} package to the NPM registry.`
-    );
-  });
-  it(`should run the \`${packageManager} publish\` command with the appropriate flags`, async () => {
-    const context: Context = mockedContextWithAuthToken;
-    const mockedCommand = vi
-      .mocked(runCommand)
-      .mockResolvedValue({ status: 0, stdout: "", stderr: "" });
-    vi.mocked(getNpmrcFile).mockReturnValue(mockedNpmrcFile);
-    await publishToRegistry(packagePublishing, context);
-    expect(mockedCommand).toHaveBeenCalledWith(packageManager, args, mockedOptions);
-    expect(mockedLogger.logSuccess).toHaveBeenCalledWith(
-      `Published release ${version} of ${packageName} package to the NPM registry on ${
-        npmTag || "default"
-      } channel.`
-    );
-    assert.deepNestedInclude(context.releaseInfos, {
-      type: "npm",
-      name: `NPM (${npmTag ?? "latest"} distribution tag)`,
-      url: `https://www.npmjs.com/package/${packageManifestName}/v/${version}`
+      );
+      const mockedCommand = vi
+        .mocked(runCommand)
+        .mockResolvedValue({ status: 128, stdout: "", stderr: "Some error message." });
+      vi.mocked(getNpmrcFile).mockReturnValue(mockedNpmrcFile);
+      vi.mocked(formatOutputFromCommandResult).mockReturnValue(expectedOutput);
+      vi.mocked(formatDetailedError).mockReturnValue(expectedError);
+      await expect(
+        publishToRegistry(packagePublishing, mockedContextWithAuthToken)
+      ).rejects.toThrow(expectedError);
+      expect(mockedCommand).toHaveBeenCalledWith(packageManager, args, mockedOptions);
+      expect(mockedLogger.logError).toHaveBeenCalledWith(
+        `Failed to publish release ${version} of ${packageName} package to the NPM registry.`
+      );
     });
-  });
-});
+    it(`should run the \`${packageManager} publish\` command with the appropriate flags`, async () => {
+      const context: Context = mockedContextWithAuthToken;
+      const mockedCommand = vi
+        .mocked(runCommand)
+        .mockResolvedValue({ status: 0, stdout: "", stderr: "" });
+      vi.mocked(getNpmrcFile).mockReturnValue(mockedNpmrcFile);
+      await publishToRegistry(packagePublishing, context);
+      expect(mockedCommand).toHaveBeenCalledWith(packageManager, args, mockedOptions);
+      expect(mockedLogger.logSuccess).toHaveBeenCalledWith(
+        `Published release ${version} of ${packageName} package to the NPM registry on ${
+          npmTag || "default"
+        } channel.`
+      );
+      assert.deepNestedInclude(context.releaseInfos, {
+        type: "npm",
+        name: `NPM (${npmTag ?? "latest"} distribution tag)`,
+        url: `https://www.npmjs.com/package/${packageManifestName}/v/${version}`
+      });
+    });
+  }
+);

--- a/packages/release-notes-generator/test/create-changelog-file.test.ts
+++ b/packages/release-notes-generator/test/create-changelog-file.test.ts
@@ -15,24 +15,27 @@ beforeEach(() => {
   vi.spyOn(fs, "existsSync").mockReturnValue(true);
 });
 
-describe.each(mockedChangelogFiles)("for $nextRelease.name", ({
-  nextRelease,
-  packageName,
-  path,
-  releaseNotesBodyWithoutChangelog,
-  formattedReleaseNotesBodyWithoutFullChangelog,
-  expectedNewChangelogFile
-}) => {
-  it("should write a new changelog file", () => {
-    const mockedSpyOn = vi
-      .spyOn(fs, "writeFileSync")
-      .mockImplementation((_path, _expectedNewChangelogFile) => undefined);
-    vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    vi.mocked(getPackageName).mockReturnValue(packageName);
-    vi.mocked(formatReleaseNotesBody).mockReturnValue(
-      formattedReleaseNotesBodyWithoutFullChangelog
-    );
-    updateChangelogFile(nextRelease, releaseNotesBodyWithoutChangelog, mockedContext.cwd);
-    expect(mockedSpyOn).toHaveBeenCalledWith(path, expectedNewChangelogFile);
-  });
-});
+describe.each(mockedChangelogFiles)(
+  "for $nextRelease.name",
+  ({
+    nextRelease,
+    packageName,
+    path,
+    releaseNotesBodyWithoutChangelog,
+    formattedReleaseNotesBodyWithoutFullChangelog,
+    expectedNewChangelogFile
+  }) => {
+    it("should write a new changelog file", () => {
+      const mockedSpyOn = vi
+        .spyOn(fs, "writeFileSync")
+        .mockImplementation((_path, _expectedNewChangelogFile) => undefined);
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      vi.mocked(getPackageName).mockReturnValue(packageName);
+      vi.mocked(formatReleaseNotesBody).mockReturnValue(
+        formattedReleaseNotesBodyWithoutFullChangelog
+      );
+      updateChangelogFile(nextRelease, releaseNotesBodyWithoutChangelog, mockedContext.cwd);
+      expect(mockedSpyOn).toHaveBeenCalledWith(path, expectedNewChangelogFile);
+    });
+  }
+);

--- a/packages/release-notes-generator/test/create-release-notes.test.ts
+++ b/packages/release-notes-generator/test/create-release-notes.test.ts
@@ -109,48 +109,48 @@ it.each(mockedFailureFetches)("$title", async ({ response, expectedError }) => {
   ).rejects.toThrow(expectedError);
   expect(process.exitCode).toBe(response.status);
 });
-describe.each(mockedReleaseNotes)("for $releaseNotes.tagName", async ({
-  releaseNotes,
-  requestBody
-}) => {
-  it.each(mockedReleaseNotesBodies)("should create release notes for $body", async ({
-    body,
-    formattedBody
-  }) => {
-    const context = {
-      ...mockedContext,
-      env: mockedEnv
-    };
-    vi.mocked(formatReleaseNotesBody).mockReturnValue(formattedBody);
-    vi.mocked(mockedFetch).mockResolvedValue({
-      status: 201,
-      statusText: "Created",
-      json: () => Promise.resolve({ message: "Created" })
-    });
-    await createReleaseNotes(
-      {
-        ...releaseNotes,
-        body
-      },
-      context
+describe.each(mockedReleaseNotes)(
+  "for $releaseNotes.tagName",
+  async ({ releaseNotes, requestBody }) => {
+    it.each(mockedReleaseNotesBodies)(
+      "should create release notes for $body",
+      async ({ body, formattedBody }) => {
+        const context = {
+          ...mockedContext,
+          env: mockedEnv
+        };
+        vi.mocked(formatReleaseNotesBody).mockReturnValue(formattedBody);
+        vi.mocked(mockedFetch).mockResolvedValue({
+          status: 201,
+          statusText: "Created",
+          json: () => Promise.resolve({ message: "Created" })
+        });
+        await createReleaseNotes(
+          {
+            ...releaseNotes,
+            body
+          },
+          context
+        );
+        expect(mockedFetch).toHaveBeenCalledWith(mockedUri, {
+          method: "POST",
+          headers: {
+            Accept: GITHUB_API_ACCEPT_HEADER,
+            Authorization: `Bearer ${mockedEnv.RELEASE_TOKEN}`,
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": GITHUB_API_VERSION
+          },
+          body: JSON.stringify({
+            ...requestBody,
+            body: formattedBody
+          })
+        });
+        assert.deepNestedInclude(context.releaseInfos, {
+          type: "github",
+          name: "GitHub release",
+          url: `${mockedRepositoryUrl}/releases/tag/${releaseNotes.tagName}`
+        });
+      }
     );
-    expect(mockedFetch).toHaveBeenCalledWith(mockedUri, {
-      method: "POST",
-      headers: {
-        Accept: GITHUB_API_ACCEPT_HEADER,
-        Authorization: `Bearer ${mockedEnv.RELEASE_TOKEN}`,
-        "Content-Type": "application/json",
-        "X-GitHub-Api-Version": GITHUB_API_VERSION
-      },
-      body: JSON.stringify({
-        ...requestBody,
-        body: formattedBody
-      })
-    });
-    assert.deepNestedInclude(context.releaseInfos, {
-      type: "github",
-      name: "GitHub release",
-      url: `${mockedRepositoryUrl}/releases/tag/${releaseNotes.tagName}`
-    });
-  });
-});
+  }
+);

--- a/packages/release-notes-generator/test/format-release-notes-body.test.ts
+++ b/packages/release-notes-generator/test/format-release-notes-body.test.ts
@@ -3,11 +3,10 @@ import { expect, it } from "vitest";
 import { formatReleaseNotesBody } from "../src/format-release-notes-body.js";
 import { mockedReleaseNotesBodies } from "./fixtures/mocked-release-notes-bodies.js";
 
-it.each(mockedReleaseNotesBodies)("should format $body in Markdown", ({
-  body,
-  formattedBody,
-  formattedBodyForChangelog
-}) => {
-  expect(formatReleaseNotesBody(body)).toBe(formattedBody);
-  expect(formatReleaseNotesBody(body, true)).toBe(formattedBodyForChangelog);
-});
+it.each(mockedReleaseNotesBodies)(
+  "should format $body in Markdown",
+  ({ body, formattedBody, formattedBodyForChangelog }) => {
+    expect(formatReleaseNotesBody(body)).toBe(formattedBody);
+    expect(formatReleaseNotesBody(body, true)).toBe(formattedBodyForChangelog);
+  }
+);

--- a/packages/release-notes-generator/test/prepare-release-notes.test.ts
+++ b/packages/release-notes-generator/test/prepare-release-notes.test.ts
@@ -170,55 +170,51 @@ it("should throw an error if no commits have been retrieved", () => {
     )
   ).toThrow(expectedError);
 });
-it.each(
-  mockedPackages
-)("should prepare release notes for branch $branch, from $lastReleasePackage.gitTag to $nextReleasePackage.gitTag", ({
-  branch,
-  commits,
-  lastReleasePackage,
-  nextReleasePackage,
-  expectedReleaseNotes
-}) => {
-  assert.deepEqual(
-    prepareReleaseNotes(nextReleasePackage, [], {
-      ...mockedContext,
-      branch,
-      lastRelease: { ref: null, packages: [lastReleasePackage] },
-      commits
-    }),
+it.each(mockedPackages)(
+  "should prepare release notes for branch $branch, from $lastReleasePackage.gitTag to $nextReleasePackage.gitTag",
+  ({ branch, commits, lastReleasePackage, nextReleasePackage, expectedReleaseNotes }) => {
+    assert.deepEqual(
+      prepareReleaseNotes(nextReleasePackage, [], {
+        ...mockedContext,
+        branch,
+        lastRelease: { ref: null, packages: [lastReleasePackage] },
+        commits
+      }),
+      expectedReleaseNotes
+    );
+  }
+);
+it.each(mockedPackagesInMonorepo)(
+  "should prepare release notes in a monorepo context for branch $branch, from $lastReleasePackage.gitTag to $nextReleasePackage.gitTag",
+  ({
+    branch,
+    commits,
+    packageDependencies,
+    nextReleasePackageDependencies,
+    lastReleasePackage,
+    nextReleasePackage,
     expectedReleaseNotes
-  );
-});
-it.each(
-  mockedPackagesInMonorepo
-)("should prepare release notes in a monorepo context for branch $branch, from $lastReleasePackage.gitTag to $nextReleasePackage.gitTag", ({
-  branch,
-  commits,
-  packageDependencies,
-  nextReleasePackageDependencies,
-  lastReleasePackage,
-  nextReleasePackage,
-  expectedReleaseNotes
-}) => {
-  assert.deepEqual(
-    prepareReleaseNotes(nextReleasePackage, packageDependencies, {
-      ...mockedContextInMonorepo,
-      branch,
-      lastRelease: {
-        ref: null,
-        packages: [
-          lastReleasePackage,
-          {
-            name: "@monorepo/b",
-            pathname: "packages/b",
-            gitTag: "null",
-            version: "1.0.0"
-          }
-        ]
-      },
-      nextRelease: [nextReleasePackage, ...nextReleasePackageDependencies],
-      commits
-    }),
-    expectedReleaseNotes
-  );
-});
+  }) => {
+    assert.deepEqual(
+      prepareReleaseNotes(nextReleasePackage, packageDependencies, {
+        ...mockedContextInMonorepo,
+        branch,
+        lastRelease: {
+          ref: null,
+          packages: [
+            lastReleasePackage,
+            {
+              name: "@monorepo/b",
+              pathname: "packages/b",
+              gitTag: "null",
+              version: "1.0.0"
+            }
+          ]
+        },
+        nextRelease: [nextReleasePackage, ...nextReleasePackageDependencies],
+        commits
+      }),
+      expectedReleaseNotes
+    );
+  }
+);

--- a/packages/release-notes-generator/test/update-changelog-file.test.ts
+++ b/packages/release-notes-generator/test/update-changelog-file.test.ts
@@ -17,46 +17,49 @@ beforeEach(() => {
   vi.spyOn(fs, "existsSync").mockReturnValue(true);
 });
 
-describe.each(mockedChangelogFiles)("for $nextRelease.name", ({
-  nextRelease,
-  packageName,
-  path,
-  releaseNotesBody,
-  releaseNotesBodyWithoutChangelog,
-  formattedReleaseNotesBody,
-  existingChangelogFile,
-  expectedUpdatedChangelogFile
-}) => {
-  it("should write a new changelog file", () => {
-    vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    vi.mocked(getPackageName).mockReturnValue(packageName);
-    updateChangelogFile(nextRelease, releaseNotesBodyWithoutChangelog, mockedContext.cwd);
-    expect(createChangelogFile).toHaveBeenCalledWith(
-      path,
-      `# ${packageName}\n\n## 1.0.0\n\n`,
-      releaseNotesBodyWithoutChangelog
-    );
-  });
-  it("should write a new changelog file if the existing one is empty", () => {
-    vi.spyOn(fs, "existsSync").mockReturnValue(true);
-    vi.spyOn(fs, "readFileSync").mockReturnValue("");
-    vi.mocked(getPackageName).mockReturnValue(packageName);
-    updateChangelogFile(nextRelease, releaseNotesBodyWithoutChangelog, mockedContext.cwd);
-    expect(createChangelogFile).toHaveBeenCalledWith(
-      path,
-      `# ${packageName}\n\n## 1.0.0\n\n`,
-      releaseNotesBodyWithoutChangelog
-    );
-  });
-  it("should update an existing changelog file", () => {
-    const mockedSpyOn = vi
-      .spyOn(fs, "writeFileSync")
-      .mockImplementation((_path, _expectedUpdatedChangelogFile) => undefined);
-    vi.spyOn(fs, "existsSync").mockReturnValue(true);
-    vi.spyOn(fs, "readFileSync").mockReturnValue(existingChangelogFile);
-    vi.mocked(getPackageName).mockReturnValue(packageName);
-    vi.mocked(formatReleaseNotesBody).mockReturnValue(formattedReleaseNotesBody);
-    updateChangelogFile(nextRelease, releaseNotesBody, mockedContext.cwd);
-    expect(mockedSpyOn).toHaveBeenCalledWith(path, expectedUpdatedChangelogFile);
-  });
-});
+describe.each(mockedChangelogFiles)(
+  "for $nextRelease.name",
+  ({
+    nextRelease,
+    packageName,
+    path,
+    releaseNotesBody,
+    releaseNotesBodyWithoutChangelog,
+    formattedReleaseNotesBody,
+    existingChangelogFile,
+    expectedUpdatedChangelogFile
+  }) => {
+    it("should write a new changelog file", () => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      vi.mocked(getPackageName).mockReturnValue(packageName);
+      updateChangelogFile(nextRelease, releaseNotesBodyWithoutChangelog, mockedContext.cwd);
+      expect(createChangelogFile).toHaveBeenCalledWith(
+        path,
+        `# ${packageName}\n\n## 1.0.0\n\n`,
+        releaseNotesBodyWithoutChangelog
+      );
+    });
+    it("should write a new changelog file if the existing one is empty", () => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(true);
+      vi.spyOn(fs, "readFileSync").mockReturnValue("");
+      vi.mocked(getPackageName).mockReturnValue(packageName);
+      updateChangelogFile(nextRelease, releaseNotesBodyWithoutChangelog, mockedContext.cwd);
+      expect(createChangelogFile).toHaveBeenCalledWith(
+        path,
+        `# ${packageName}\n\n## 1.0.0\n\n`,
+        releaseNotesBodyWithoutChangelog
+      );
+    });
+    it("should update an existing changelog file", () => {
+      const mockedSpyOn = vi
+        .spyOn(fs, "writeFileSync")
+        .mockImplementation((_path, _expectedUpdatedChangelogFile) => undefined);
+      vi.spyOn(fs, "existsSync").mockReturnValue(true);
+      vi.spyOn(fs, "readFileSync").mockReturnValue(existingChangelogFile);
+      vi.mocked(getPackageName).mockReturnValue(packageName);
+      vi.mocked(formatReleaseNotesBody).mockReturnValue(formattedReleaseNotesBody);
+      updateChangelogFile(nextRelease, releaseNotesBody, mockedContext.cwd);
+      expect(mockedSpyOn).toHaveBeenCalledWith(path, expectedUpdatedChangelogFile);
+    });
+  }
+);

--- a/packages/release/test/get-version-from-tag.test.ts
+++ b/packages/release/test/get-version-from-tag.test.ts
@@ -16,8 +16,9 @@ it("should throw an error if the version is invalid", () => {
     })
   );
 });
-it.each(
-  mockedVersionsFromGitTag
-)("should return the version $1 from $0 if it is valid", (gitTag, version) => {
-  expect(getVersionFromTag(gitTag)).toBe(version);
-});
+it.each(mockedVersionsFromGitTag)(
+  "should return the version $1 from $0 if it is valid",
+  (gitTag, version) => {
+    expect(getVersionFromTag(gitTag)).toBe(version);
+  }
+);

--- a/packages/release/test/increment-version.test.ts
+++ b/packages/release/test/increment-version.test.ts
@@ -53,25 +53,25 @@ it("should throw an error if the current version is invalid", () => {
     })
   );
 });
-describe.each(mockedReleases)("increment version from $currentVersion", ({
-  currentVersion,
-  branches
-}) => {
-  for (const key in branches) {
-    const branch = branches[key];
-    const mockedBranchConfig = mockedBranchConfigs[key];
-    if (branch && mockedBranchConfig) {
-      for (const releaseType in branch) {
-        const expectedVersion = branch[releaseType];
-        it.runIf(mockedReleaseTypes.includes(releaseType))(
-          `should return '${expectedVersion}' if release type is '${releaseType}' for branch ${key}`,
-          () => {
-            expect(
-              incrementVersion(currentVersion, releaseType as ReleaseType, mockedBranchConfig)
-            ).toBe(expectedVersion);
-          }
-        );
+describe.each(mockedReleases)(
+  "increment version from $currentVersion",
+  ({ currentVersion, branches }) => {
+    for (const key in branches) {
+      const branch = branches[key];
+      const mockedBranchConfig = mockedBranchConfigs[key];
+      if (branch && mockedBranchConfig) {
+        for (const releaseType in branch) {
+          const expectedVersion = branch[releaseType];
+          it.runIf(mockedReleaseTypes.includes(releaseType))(
+            `should return '${expectedVersion}' if release type is '${releaseType}' for branch ${key}`,
+            () => {
+              expect(
+                incrementVersion(currentVersion, releaseType as ReleaseType, mockedBranchConfig)
+              ).toBe(expectedVersion);
+            }
+          );
+        }
       }
     }
   }
-});
+);

--- a/packages/release/test/publish.test.ts
+++ b/packages/release/test/publish.test.ts
@@ -134,23 +134,23 @@ it("should not call any functions allowing to switch to a new branch if `context
   expect(setBranchName).not.toHaveBeenCalled();
   expect(switchToNewBranch).not.toHaveBeenCalled();
 });
-it.each([
-  mockedContext,
-  { ...mockedContext, nextRelease: [] }
-])("should not call any functions allowing to publish any packages if `context.nextRelease` is undefined or an empty array", async context => {
-  await publish(context);
-  expect(getPackageDependencies).not.toHaveBeenCalled();
-  expect(prepareReleaseNotes).not.toHaveBeenCalled();
-  expect(updatePackageVersion).not.toHaveBeenCalled();
-  expect(updatePackageDependenciesVersions).not.toHaveBeenCalled();
-  expect(updateLockFile).not.toHaveBeenCalled();
-  expect(updateChangelogFile).not.toHaveBeenCalled();
-  expect(commitUpdatedFiles).not.toHaveBeenCalled();
-  expect(createTag).not.toHaveBeenCalled();
-  expect(preparePublishing).not.toHaveBeenCalled();
-  expect(publishToRegistry).not.toHaveBeenCalled();
-  expect(createReleaseNotes).not.toHaveBeenCalled();
-});
+it.each([mockedContext, { ...mockedContext, nextRelease: [] }])(
+  "should not call any functions allowing to publish any packages if `context.nextRelease` is undefined or an empty array",
+  async context => {
+    await publish(context);
+    expect(getPackageDependencies).not.toHaveBeenCalled();
+    expect(prepareReleaseNotes).not.toHaveBeenCalled();
+    expect(updatePackageVersion).not.toHaveBeenCalled();
+    expect(updatePackageDependenciesVersions).not.toHaveBeenCalled();
+    expect(updateLockFile).not.toHaveBeenCalled();
+    expect(updateChangelogFile).not.toHaveBeenCalled();
+    expect(commitUpdatedFiles).not.toHaveBeenCalled();
+    expect(createTag).not.toHaveBeenCalled();
+    expect(preparePublishing).not.toHaveBeenCalled();
+    expect(publishToRegistry).not.toHaveBeenCalled();
+    expect(createReleaseNotes).not.toHaveBeenCalled();
+  }
+);
 it("should throw an error if the package manager is not found or unsupported", async () => {
   const expectedErrorMessage =
     "Failed to find the package manager: The package manager is not found or is not one of those supported (npm or pnpm).";
@@ -178,475 +178,476 @@ describe.each(packageManagers)("for %s", packageManager => {
   afterEach(() => {
     vi.clearAllMocks();
   });
-  describe.each([
-    mockedContextWithNextRelease,
-    mockedContextInMonorepoWithNextRelease
-  ])("for isMonorepo: $config.isMonorepo", context => {
-    const mockedReleaseBranch = "release-change/main/1.2.3";
-    const mockedPullRequestReference = { pullRequestNumber: 123, pullRequestId: "fake_ID" };
+  describe.each([mockedContextWithNextRelease, mockedContextInMonorepoWithNextRelease])(
+    "for isMonorepo: $config.isMonorepo",
+    context => {
+      const mockedReleaseBranch = "release-change/main/1.2.3";
+      const mockedPullRequestReference = { pullRequestNumber: 123, pullRequestId: "fake_ID" };
 
-    beforeEach(() => {
-      vi.mocked(getPackageDependencies).mockReturnValue([]);
-      vi.mocked(prepareReleaseNotes).mockReturnValue(mockedReleaseNotes);
-      vi.mocked(updatePackageVersion).mockImplementation(() => undefined);
-      vi.mocked(updateLockFile).mockResolvedValue();
-      vi.mocked(updateChangelogFile).mockImplementation(() => undefined);
-      vi.mocked(commitUpdatedFiles).mockResolvedValue("commit message");
-      vi.mocked(getCurrentCommitId).mockReturnValue("0123456");
-      vi.mocked(createTag).mockImplementation(() => undefined);
-      vi.mocked(createReleaseNotes).mockResolvedValue();
-      vi.mocked(preparePublishing).mockResolvedValue(null);
-      vi.mocked(getRepositoryMergeInfo).mockResolvedValue({
-        autoMergeAllowed: true,
-        mergeCommitAllowed: true,
-        rebaseMergeAllowed: true,
-        squashMergeAllowed: true
+      beforeEach(() => {
+        vi.mocked(getPackageDependencies).mockReturnValue([]);
+        vi.mocked(prepareReleaseNotes).mockReturnValue(mockedReleaseNotes);
+        vi.mocked(updatePackageVersion).mockImplementation(() => undefined);
+        vi.mocked(updateLockFile).mockResolvedValue();
+        vi.mocked(updateChangelogFile).mockImplementation(() => undefined);
+        vi.mocked(commitUpdatedFiles).mockResolvedValue("commit message");
+        vi.mocked(getCurrentCommitId).mockReturnValue("0123456");
+        vi.mocked(createTag).mockImplementation(() => undefined);
+        vi.mocked(createReleaseNotes).mockResolvedValue();
+        vi.mocked(preparePublishing).mockResolvedValue(null);
+        vi.mocked(getRepositoryMergeInfo).mockResolvedValue({
+          autoMergeAllowed: true,
+          mergeCommitAllowed: true,
+          rebaseMergeAllowed: true,
+          squashMergeAllowed: true
+        });
       });
-    });
-    afterEach(() => {
-      vi.clearAllMocks();
-    });
-    it("should throw an error if the package manifest file is not found", async () => {
-      const expectedErrorMessage =
-        "Failed to find the package manifest file: Package /fake/path/package.json not found for root package.";
-      const expectedError = new Error(expectedErrorMessage, {
-        cause: {
-          title: "Failed to find the package manifest file.",
-          message: "Package /fake/path/package.json not found for root package.",
-          details: {
-            output: "fs.existsSync(/fake/path/package.json): false"
-          }
-        }
+      afterEach(() => {
+        vi.clearAllMocks();
       });
-      vi.spyOn(fs, "existsSync").mockReturnValue(false);
-      vi.mocked(updatePackageVersion).mockImplementation(() => {
-        throw expectedError;
-      });
-      await expect(publish(context)).rejects.toThrow(expectedErrorMessage);
-      expect(mockedLogger.logError).toHaveBeenCalledWith("Failed to publish the release.");
-      assert.deepNestedInclude(context.errors, expectedError.cause);
-    });
-    it("should throw an error if the commit reference ID is empty", async () => {
-      const expectedErrorMessage =
-        "Failed to create a Git tag: The commit reference must not be empty.";
-      const expectedError = new Error(expectedErrorMessage, {
-        cause: {
-          title: "Failed to create a Git tag.",
-          message: "The commit reference must not be empty.",
-          details: {
-            output: "commitRef: "
+      it("should throw an error if the package manifest file is not found", async () => {
+        const expectedErrorMessage =
+          "Failed to find the package manifest file: Package /fake/path/package.json not found for root package.";
+        const expectedError = new Error(expectedErrorMessage, {
+          cause: {
+            title: "Failed to find the package manifest file.",
+            message: "Package /fake/path/package.json not found for root package.",
+            details: {
+              output: "fs.existsSync(/fake/path/package.json): false"
+            }
           }
-        }
-      });
-      vi.mocked(getCurrentCommitId).mockReturnValue("");
-      vi.mocked(createTag).mockImplementation(() => {
-        throw expectedError;
-      });
-      await expect(publish(context)).rejects.toThrow(expectedErrorMessage);
-      expect(mockedLogger.logError).toHaveBeenCalledWith("Failed to publish the release.");
-      assert.deepNestedInclude(context.errors, expectedError.cause);
-    });
-    describe.each([
-      {
-        case: "if the branch is not defined",
-        errorMessage: "Failed to prepare the release notes: The branch is not defined.",
-        errorCause: {
-          title: "Failed to prepare the release notes",
-          message: "The branch is not defined.",
-          details: {
-            output: "branch: undefined"
-          }
-        }
-      },
-      {
-        case: "if the branch is not defined in the configuration",
-        errorMessage:
-          "Failed to prepare the release notes: The branch unknown is not defined in the configuration.",
-        errorCause: {
-          title: "Failed to prepare the release notes",
-          message: "The branch unknown is not defined in the configuration.",
-          details: {
-            output: "branch: unknown"
-          }
-        }
-      },
-      {
-        case: "if the last release is not defined",
-        errorMessage: "Failed to prepare the release notes: The last release is not defined.",
-        errorCause: {
-          title: "Failed to prepare the release notes",
-          message: "The last release is not defined.",
-          details: {
-            output: "lastRelease: undefined"
-          }
-        }
-      },
-      {
-        case: "if the last release is not found for the package",
-        errorMessage:
-          "Failed to prepare the release notes: No last release found for root package.",
-        errorCause: {
-          title: "Failed to prepare the release notes",
-          message: "No last release found for root package.",
-          details: {
-            output: "packageLastRelease: undefined"
-          }
-        }
-      },
-      {
-        case: "if no commits have been retrieved",
-        errorMessage: "Failed to prepare the release notes: No commits have been retrieved.",
-        errorCause: {
-          title: "Failed to prepare the release notes",
-          message: "No commits have been retrieved.",
-          details: {
-            output: "commits: undefined"
-          }
-        }
-      }
-    ])("$case", ({ errorMessage, errorCause }) => {
-      it("should throw an error", async () => {
-        const expectedError = new Error(errorMessage, { cause: errorCause });
-        vi.mocked(prepareReleaseNotes).mockImplementation(() => {
+        });
+        vi.spyOn(fs, "existsSync").mockReturnValue(false);
+        vi.mocked(updatePackageVersion).mockImplementation(() => {
           throw expectedError;
         });
-        await expect(publish(context)).rejects.toThrow(expectedError);
+        await expect(publish(context)).rejects.toThrow(expectedErrorMessage);
         expect(mockedLogger.logError).toHaveBeenCalledWith("Failed to publish the release.");
         assert.deepNestedInclude(context.errors, expectedError.cause);
       });
-    });
-    if (context.config.isMonorepo) {
-      it("should update package dependencies when in monorepo with dependencies", async () => {
-        vi.mocked(getPackageDependencies).mockReturnValue(["@monorepo/c"]);
-        await publish(context);
-        expect(updatePackageDependenciesVersions).toHaveBeenCalled();
+      it("should throw an error if the commit reference ID is empty", async () => {
+        const expectedErrorMessage =
+          "Failed to create a Git tag: The commit reference must not be empty.";
+        const expectedError = new Error(expectedErrorMessage, {
+          cause: {
+            title: "Failed to create a Git tag.",
+            message: "The commit reference must not be empty.",
+            details: {
+              output: "commitRef: "
+            }
+          }
+        });
+        vi.mocked(getCurrentCommitId).mockReturnValue("");
+        vi.mocked(createTag).mockImplementation(() => {
+          throw expectedError;
+        });
+        await expect(publish(context)).rejects.toThrow(expectedErrorMessage);
+        expect(mockedLogger.logError).toHaveBeenCalledWith("Failed to publish the release.");
+        assert.deepNestedInclude(context.errors, expectedError.cause);
       });
-      it("should not update package dependencies when dependencies are `null`", async () => {
-        vi.mocked(getPackageDependencies).mockReturnValue(null);
-        await publish(context);
-        expect(updatePackageDependenciesVersions).not.toHaveBeenCalled();
+      describe.each([
+        {
+          case: "if the branch is not defined",
+          errorMessage: "Failed to prepare the release notes: The branch is not defined.",
+          errorCause: {
+            title: "Failed to prepare the release notes",
+            message: "The branch is not defined.",
+            details: {
+              output: "branch: undefined"
+            }
+          }
+        },
+        {
+          case: "if the branch is not defined in the configuration",
+          errorMessage:
+            "Failed to prepare the release notes: The branch unknown is not defined in the configuration.",
+          errorCause: {
+            title: "Failed to prepare the release notes",
+            message: "The branch unknown is not defined in the configuration.",
+            details: {
+              output: "branch: unknown"
+            }
+          }
+        },
+        {
+          case: "if the last release is not defined",
+          errorMessage: "Failed to prepare the release notes: The last release is not defined.",
+          errorCause: {
+            title: "Failed to prepare the release notes",
+            message: "The last release is not defined.",
+            details: {
+              output: "lastRelease: undefined"
+            }
+          }
+        },
+        {
+          case: "if the last release is not found for the package",
+          errorMessage:
+            "Failed to prepare the release notes: No last release found for root package.",
+          errorCause: {
+            title: "Failed to prepare the release notes",
+            message: "No last release found for root package.",
+            details: {
+              output: "packageLastRelease: undefined"
+            }
+          }
+        },
+        {
+          case: "if no commits have been retrieved",
+          errorMessage: "Failed to prepare the release notes: No commits have been retrieved.",
+          errorCause: {
+            title: "Failed to prepare the release notes",
+            message: "No commits have been retrieved.",
+            details: {
+              output: "commits: undefined"
+            }
+          }
+        }
+      ])("$case", ({ errorMessage, errorCause }) => {
+        it("should throw an error", async () => {
+          const expectedError = new Error(errorMessage, { cause: errorCause });
+          vi.mocked(prepareReleaseNotes).mockImplementation(() => {
+            throw expectedError;
+          });
+          await expect(publish(context)).rejects.toThrow(expectedError);
+          expect(mockedLogger.logError).toHaveBeenCalledWith("Failed to publish the release.");
+          assert.deepNestedInclude(context.errors, expectedError.cause);
+        });
       });
-    } else {
-      it("should not update package dependencies when not in monorepo", async () => {
-        vi.mocked(getPackageDependencies).mockReturnValue(["some-package"]);
+      if (context.config.isMonorepo) {
+        it("should update package dependencies when in monorepo with dependencies", async () => {
+          vi.mocked(getPackageDependencies).mockReturnValue(["@monorepo/c"]);
+          await publish(context);
+          expect(updatePackageDependenciesVersions).toHaveBeenCalled();
+        });
+        it("should not update package dependencies when dependencies are `null`", async () => {
+          vi.mocked(getPackageDependencies).mockReturnValue(null);
+          await publish(context);
+          expect(updatePackageDependenciesVersions).not.toHaveBeenCalled();
+        });
+      } else {
+        it("should not update package dependencies when not in monorepo", async () => {
+          vi.mocked(getPackageDependencies).mockReturnValue(["some-package"]);
+          await publish(context);
+          expect(updatePackageDependenciesVersions).not.toHaveBeenCalled();
+        });
+      }
+      it("should execute the full publishing workflow successfully", async () => {
+        const mockedBranch = "release-change/main/1.2.3";
+        const args =
+          packageManager === "pnpm"
+            ? ["publish", "--access", "public", "--not-git-checks"]
+            : ["publish", "--access", "public"];
+        vi.mocked(setBranchName).mockReturnValue(mockedBranch);
+        vi.mocked(getPackageDependencies).mockReturnValue([]);
+        vi.mocked(prepareReleaseNotes).mockReturnValue(mockedReleaseNotes);
+        vi.mocked(getCurrentCommitId).mockReturnValue("abc123");
+        vi.mocked(preparePublishing).mockResolvedValue({
+          name: "",
+          packageManifestName: "foo",
+          pathname: ".",
+          version: "1.0.0",
+          packageManager,
+          args
+        });
         await publish(context);
-        expect(updatePackageDependenciesVersions).not.toHaveBeenCalled();
+        expect(push).toHaveBeenCalledWith(context, {
+          destinationBranch: mockedBranch,
+          includeTags: true
+        });
+        expect(getRepositoryMergeInfo).toHaveBeenCalled();
+        expect(createPullRequest).toHaveBeenCalled();
+        expect(enableAutoMerge).toHaveBeenCalled();
+        expect(createReleaseNotes).toHaveBeenCalled();
+        expect(publishToRegistry).toHaveBeenCalled();
+      });
+      it("should rollback commits and delete release branch when `git add` fails", async () => {
+        const { branch, cwd } = context;
+        const mockedError = new Error(
+          "Failed to run the `git add` command: The command failed with status 128.",
+          {
+            cause: {
+              title: "Failed to run the `git add` command",
+              message: "The command failed with status 128.",
+              details: {
+                output: "Git error",
+                command:
+                  "git add /fake/path/package.json /fake/path/package-lock.json /fake/path/CHANGELOG.md"
+              }
+            }
+          }
+        );
+        vi.mocked(getCurrentCommitId).mockReturnValue("original-commit");
+        vi.mocked(commitUpdatedFiles).mockRejectedValue(mockedError);
+        vi.mocked(isDetailedError).mockReturnValue(true);
+        await expect(publish(context)).rejects.toThrow(mockedError);
+        expect(cancelCommitsSinceRef).toHaveBeenCalledWith(
+          "original-commit",
+          expect.any(String),
+          expect.any(Boolean)
+        );
+        expect(switchToBranch).toHaveBeenCalledWith(branch, cwd);
+        expect(deleteBranch).toHaveBeenCalledWith(mockedReleaseBranch, cwd, expect.any(Boolean));
+        expect(deleteBranchOnRemoteRepository).toHaveBeenCalled();
+        expect(removeTag).not.toHaveBeenCalled();
+        expect(removeTagOnRemoteRepository).not.toHaveBeenCalled();
+      });
+      it("should rollback commits and delete release branch when `git commit` fails", async () => {
+        const { branch, cwd } = context;
+        const mockedError = new Error(
+          "Failed to run the `git commit` command: The command failed with status 128.",
+          {
+            cause: {
+              title: "Failed to run the `git commit` command",
+              message: "The command failed with status 128.",
+              details: {
+                output: "Git error",
+                command: "git commit -m 'chore: v1.0.0'"
+              }
+            }
+          }
+        );
+        vi.mocked(getCurrentCommitId).mockReturnValue("original-commit");
+        vi.mocked(commitUpdatedFiles).mockRejectedValue(mockedError);
+        await expect(publish(context)).rejects.toThrow(mockedError);
+        expect(cancelCommitsSinceRef).toHaveBeenCalledWith(
+          "original-commit",
+          expect.any(String),
+          expect.any(Boolean)
+        );
+        expect(switchToBranch).toHaveBeenCalledWith(branch, cwd);
+        expect(deleteBranch).toHaveBeenCalledWith(mockedReleaseBranch, cwd, expect.any(Boolean));
+        expect(deleteBranchOnRemoteRepository).toHaveBeenCalled();
+        expect(removeTag).not.toHaveBeenCalled();
+        expect(removeTagOnRemoteRepository).not.toHaveBeenCalled();
+      });
+      it("should rollback commits, remove tags and delete release branch when push fails", async () => {
+        const { branch, cwd } = context;
+        const mockedError = new Error(
+          "Failed to run the `git push` command: The command failed with status 128.",
+          {
+            cause: {
+              title: "Failed to run the `git push` command",
+              message: "The command failed with status 128.",
+              details: {
+                output: "Git error",
+                command: `git push --follow-tags origin ${mockedReleaseBranch}`
+              }
+            }
+          }
+        );
+        vi.mocked(setBranchName).mockReturnValue(mockedReleaseBranch);
+        vi.mocked(getCurrentCommitId).mockReturnValue("original-commit");
+        vi.mocked(push).mockRejectedValue(mockedError);
+        await expect(publish(context)).rejects.toThrow(mockedError);
+        expect(cancelCommitsSinceRef).toHaveBeenCalledWith(
+          "original-commit",
+          expect.any(String),
+          expect.any(Boolean)
+        );
+        expect(switchToBranch).toHaveBeenCalledWith(branch, cwd);
+        expect(deleteBranch).toHaveBeenCalledWith(mockedReleaseBranch, cwd, expect.any(Boolean));
+        expect(deleteBranchOnRemoteRepository).toHaveBeenCalled();
+        expect(removeTag).toHaveBeenCalled();
+        expect(removeTagOnRemoteRepository).toHaveBeenCalled();
+      });
+      it("should rollback commits, remove tags and delete release branch when repository merge options request fails", async () => {
+        const { branch, cwd } = context;
+        const mockedError = new Error(
+          "Failed to get the information about the repository merge options: The GitHub API failed to provide information about the repository merge options.",
+          {
+            cause: {
+              title: "Failed to get the information about the repository merge options",
+              message:
+                "The GitHub API failed to provide information about the repository merge options.",
+              details: {
+                output: "{}",
+                command:
+                  "POST https://api.github.com/graphql query($owner, $repository) { repository(owner, name) {} }"
+              }
+            }
+          }
+        );
+        vi.mocked(getRepositoryMergeInfo).mockRejectedValue(mockedError);
+        await expect(publish(context)).rejects.toThrow(mockedError);
+        expect(cancelCommitsSinceRef).toHaveBeenCalledWith(
+          "0123456",
+          expect.any(String),
+          expect.any(Boolean)
+        );
+        expect(switchToBranch).toHaveBeenCalledWith(branch, cwd);
+        expect(deleteBranch).toHaveBeenCalledWith(mockedReleaseBranch, cwd, expect.any(Boolean));
+        expect(deleteBranchOnRemoteRepository).toHaveBeenCalled();
+        expect(removeTag).toHaveBeenCalled();
+        expect(removeTagOnRemoteRepository).toHaveBeenCalled();
+      });
+      it("should rollback commits, remove tags and delete release branch when pull request creation fails", async () => {
+        const { branch, cwd } = context;
+        const mockedError = new Error(
+          "Failed to create the pull request: The command failed with status 128.",
+          {
+            cause: {
+              title: "Failed to create the pull request",
+              message: "The command failed with status 128.",
+              details: {
+                output: "GitHub API error",
+                command: "POST /repos/:owner/:repo/pulls"
+              }
+            }
+          }
+        );
+        vi.mocked(createPullRequest).mockRejectedValue(mockedError);
+        await expect(publish(context)).rejects.toThrow(mockedError);
+        expect(cancelCommitsSinceRef).toHaveBeenCalledWith(
+          "0123456",
+          expect.any(String),
+          expect.any(Boolean)
+        );
+        expect(switchToBranch).toHaveBeenCalledWith(branch, cwd);
+        expect(deleteBranch).toHaveBeenCalledWith(mockedReleaseBranch, cwd, expect.any(Boolean));
+        expect(deleteBranchOnRemoteRepository).toHaveBeenCalled();
+        expect(removeTag).toHaveBeenCalled();
+        expect(removeTagOnRemoteRepository).toHaveBeenCalled();
+      });
+      it("should rollback commits, remove tags and delete release branch when release notes creation fails", async () => {
+        const { branch, cwd } = context;
+        const mockedError = new Error(
+          "Failed to create the release notes: Failed to fetch URI https://api.github.com/repos/user-id/repo-name/releases",
+          {
+            cause: {
+              title: "Failed to create the release notes",
+              message:
+                "Failed to fetch URI https://api.github.com/repos/user-id/repo-name/releases",
+              details: {
+                output: "GitHub API error",
+                command: "POST https://api.github.com/repos/user-id/repo-name/releases"
+              }
+            }
+          }
+        );
+        vi.mocked(createReleaseNotes).mockRejectedValue(mockedError);
+        await expect(publish(context)).rejects.toThrow(mockedError);
+        expect(cancelCommitsSinceRef).toHaveBeenCalledWith(
+          "0123456",
+          expect.any(String),
+          expect.any(Boolean)
+        );
+        expect(switchToBranch).toHaveBeenCalledWith(branch, cwd);
+        expect(deleteBranch).toHaveBeenCalledWith(mockedReleaseBranch, cwd, expect.any(Boolean));
+        expect(deleteBranchOnRemoteRepository).toHaveBeenCalled();
+        expect(removeTag).toHaveBeenCalled();
+        expect(removeTagOnRemoteRepository).toHaveBeenCalled();
+      });
+      it("should not rollback when error is not from `git add`, `git commit`, `git push`, repository merge options request, pull request creation or release notes creation", async () => {
+        vi.mocked(updateLockFile).mockRejectedValue(new Error("Lock file update failed"));
+        await expect(publish(context)).rejects.toThrow();
+        expect(cancelCommitsSinceRef).not.toHaveBeenCalled();
+        expect(switchToBranch).not.toHaveBeenCalled();
+        expect(deleteBranch).not.toHaveBeenCalled();
+        expect(deleteBranchOnRemoteRepository).not.toHaveBeenCalled();
+        expect(removeTag).not.toHaveBeenCalled();
+        expect(removeTagOnRemoteRepository).not.toHaveBeenCalled();
+      });
+      it("should set `process.exitCode` to 1 on error", async () => {
+        vi.mocked(push).mockRejectedValue(new Error("Some error"));
+        await expect(publish(context)).rejects.toThrow();
+        expect(process.exitCode).toBe(1);
+      });
+      it("should create all tags before pushing", async () => {
+        const operations: string[] = [];
+        vi.mocked(createTag).mockImplementation(() => {
+          operations.push("tag");
+        });
+        vi.mocked(push).mockImplementation(async () => {
+          operations.push("push");
+        });
+        vi.mocked(createPullRequest).mockImplementation(async () => {
+          operations.push("pullRequest");
+          return mockedPullRequestReference;
+        });
+        await publish(context);
+        expect(operations.lastIndexOf("tag")).toBeLessThan(operations.indexOf("push"));
+      });
+      it("should not add to `packagePublishingSet` when `preparePublishing` returns `null`", async () => {
+        await publish(context);
+        expect(publishToRegistry).not.toHaveBeenCalled();
+      });
+      it("should collect all Git tags during package processing", async () => {
+        await publish(context);
+        const gitTags = context.nextRelease.map(packageItem => packageItem.gitTag);
+        for (const gitTag of gitTags) {
+          expect(createTag).toHaveBeenCalledWith(
+            expect.objectContaining({ gitTag }),
+            expect.any(String),
+            expect.any(Boolean)
+          );
+        }
+      });
+      it("should remove all created tags on rollback", async () => {
+        const mockedBranch = "release-change/main/1.2.3";
+        const mockedError = new Error(
+          "Failed to run the `git push` command: The command failed with status 128.",
+          {
+            cause: {
+              title: "Failed to run the `git push` command",
+              message: "The command failed with status 128.",
+              details: {
+                output: "Git error",
+                command: `git push --follow-tags origin ${mockedBranch}`
+              }
+            }
+          }
+        );
+        vi.mocked(push).mockRejectedValue(mockedError);
+        await expect(publish(context)).rejects.toThrow(mockedError);
+        expect(removeTag).toHaveBeenCalledTimes(context.nextRelease.length);
+        expect(removeTagOnRemoteRepository).toHaveBeenCalledTimes(context.nextRelease.length);
+        for (const packageNextRelease of context.nextRelease) {
+          expect(removeTag).toHaveBeenCalledWith(
+            packageNextRelease.gitTag,
+            expect.any(String),
+            expect.any(Boolean)
+          );
+          expect(removeTagOnRemoteRepository).toHaveBeenCalledWith(
+            packageNextRelease.gitTag,
+            context
+          );
+        }
+      });
+      it("should create release notes for all packages", async () => {
+        await publish(context);
+        expect(createReleaseNotes).toHaveBeenCalledTimes(context.nextRelease.length);
+      });
+      it("should create release notes after successful push", async () => {
+        const operations: string[] = [];
+        vi.mocked(push).mockImplementation(async () => {
+          operations.push("push");
+        });
+        vi.mocked(createPullRequest).mockImplementation(async () => {
+          operations.push("pullRequest");
+          return mockedPullRequestReference;
+        });
+        vi.mocked(createReleaseNotes).mockImplementation(async () => {
+          operations.push("releaseNotes");
+        });
+        await publish(context);
+        expect(operations.lastIndexOf("push")).toBeLessThan(operations.indexOf("releaseNotes"));
+      });
+      it("should handle non-Error exceptions", async () => {
+        vi.mocked(push).mockRejectedValue("String error");
+        await expect(publish(context)).rejects.toThrow("String error");
+      });
+      it("should preserve error cause when rethrowing", async () => {
+        vi.mocked(push).mockRejectedValue(new Error("Original", { cause: "custom-cause" }));
+        try {
+          await publish(context);
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+          expect.objectContaining({ cause: "custom-cause" });
+        }
       });
     }
-    it("should execute the full publishing workflow successfully", async () => {
-      const mockedBranch = "release-change/main/1.2.3";
-      const args =
-        packageManager === "pnpm"
-          ? ["publish", "--access", "public", "--not-git-checks"]
-          : ["publish", "--access", "public"];
-      vi.mocked(setBranchName).mockReturnValue(mockedBranch);
-      vi.mocked(getPackageDependencies).mockReturnValue([]);
-      vi.mocked(prepareReleaseNotes).mockReturnValue(mockedReleaseNotes);
-      vi.mocked(getCurrentCommitId).mockReturnValue("abc123");
-      vi.mocked(preparePublishing).mockResolvedValue({
-        name: "",
-        packageManifestName: "foo",
-        pathname: ".",
-        version: "1.0.0",
-        packageManager,
-        args
-      });
-      await publish(context);
-      expect(push).toHaveBeenCalledWith(context, {
-        destinationBranch: mockedBranch,
-        includeTags: true
-      });
-      expect(getRepositoryMergeInfo).toHaveBeenCalled();
-      expect(createPullRequest).toHaveBeenCalled();
-      expect(enableAutoMerge).toHaveBeenCalled();
-      expect(createReleaseNotes).toHaveBeenCalled();
-      expect(publishToRegistry).toHaveBeenCalled();
-    });
-    it("should rollback commits and delete release branch when `git add` fails", async () => {
-      const { branch, cwd } = context;
-      const mockedError = new Error(
-        "Failed to run the `git add` command: The command failed with status 128.",
-        {
-          cause: {
-            title: "Failed to run the `git add` command",
-            message: "The command failed with status 128.",
-            details: {
-              output: "Git error",
-              command:
-                "git add /fake/path/package.json /fake/path/package-lock.json /fake/path/CHANGELOG.md"
-            }
-          }
-        }
-      );
-      vi.mocked(getCurrentCommitId).mockReturnValue("original-commit");
-      vi.mocked(commitUpdatedFiles).mockRejectedValue(mockedError);
-      vi.mocked(isDetailedError).mockReturnValue(true);
-      await expect(publish(context)).rejects.toThrow(mockedError);
-      expect(cancelCommitsSinceRef).toHaveBeenCalledWith(
-        "original-commit",
-        expect.any(String),
-        expect.any(Boolean)
-      );
-      expect(switchToBranch).toHaveBeenCalledWith(branch, cwd);
-      expect(deleteBranch).toHaveBeenCalledWith(mockedReleaseBranch, cwd, expect.any(Boolean));
-      expect(deleteBranchOnRemoteRepository).toHaveBeenCalled();
-      expect(removeTag).not.toHaveBeenCalled();
-      expect(removeTagOnRemoteRepository).not.toHaveBeenCalled();
-    });
-    it("should rollback commits and delete release branch when `git commit` fails", async () => {
-      const { branch, cwd } = context;
-      const mockedError = new Error(
-        "Failed to run the `git commit` command: The command failed with status 128.",
-        {
-          cause: {
-            title: "Failed to run the `git commit` command",
-            message: "The command failed with status 128.",
-            details: {
-              output: "Git error",
-              command: "git commit -m 'chore: v1.0.0'"
-            }
-          }
-        }
-      );
-      vi.mocked(getCurrentCommitId).mockReturnValue("original-commit");
-      vi.mocked(commitUpdatedFiles).mockRejectedValue(mockedError);
-      await expect(publish(context)).rejects.toThrow(mockedError);
-      expect(cancelCommitsSinceRef).toHaveBeenCalledWith(
-        "original-commit",
-        expect.any(String),
-        expect.any(Boolean)
-      );
-      expect(switchToBranch).toHaveBeenCalledWith(branch, cwd);
-      expect(deleteBranch).toHaveBeenCalledWith(mockedReleaseBranch, cwd, expect.any(Boolean));
-      expect(deleteBranchOnRemoteRepository).toHaveBeenCalled();
-      expect(removeTag).not.toHaveBeenCalled();
-      expect(removeTagOnRemoteRepository).not.toHaveBeenCalled();
-    });
-    it("should rollback commits, remove tags and delete release branch when push fails", async () => {
-      const { branch, cwd } = context;
-      const mockedError = new Error(
-        "Failed to run the `git push` command: The command failed with status 128.",
-        {
-          cause: {
-            title: "Failed to run the `git push` command",
-            message: "The command failed with status 128.",
-            details: {
-              output: "Git error",
-              command: `git push --follow-tags origin ${mockedReleaseBranch}`
-            }
-          }
-        }
-      );
-      vi.mocked(setBranchName).mockReturnValue(mockedReleaseBranch);
-      vi.mocked(getCurrentCommitId).mockReturnValue("original-commit");
-      vi.mocked(push).mockRejectedValue(mockedError);
-      await expect(publish(context)).rejects.toThrow(mockedError);
-      expect(cancelCommitsSinceRef).toHaveBeenCalledWith(
-        "original-commit",
-        expect.any(String),
-        expect.any(Boolean)
-      );
-      expect(switchToBranch).toHaveBeenCalledWith(branch, cwd);
-      expect(deleteBranch).toHaveBeenCalledWith(mockedReleaseBranch, cwd, expect.any(Boolean));
-      expect(deleteBranchOnRemoteRepository).toHaveBeenCalled();
-      expect(removeTag).toHaveBeenCalled();
-      expect(removeTagOnRemoteRepository).toHaveBeenCalled();
-    });
-    it("should rollback commits, remove tags and delete release branch when repository merge options request fails", async () => {
-      const { branch, cwd } = context;
-      const mockedError = new Error(
-        "Failed to get the information about the repository merge options: The GitHub API failed to provide information about the repository merge options.",
-        {
-          cause: {
-            title: "Failed to get the information about the repository merge options",
-            message:
-              "The GitHub API failed to provide information about the repository merge options.",
-            details: {
-              output: "{}",
-              command:
-                "POST https://api.github.com/graphql query($owner, $repository) { repository(owner, name) {} }"
-            }
-          }
-        }
-      );
-      vi.mocked(getRepositoryMergeInfo).mockRejectedValue(mockedError);
-      await expect(publish(context)).rejects.toThrow(mockedError);
-      expect(cancelCommitsSinceRef).toHaveBeenCalledWith(
-        "0123456",
-        expect.any(String),
-        expect.any(Boolean)
-      );
-      expect(switchToBranch).toHaveBeenCalledWith(branch, cwd);
-      expect(deleteBranch).toHaveBeenCalledWith(mockedReleaseBranch, cwd, expect.any(Boolean));
-      expect(deleteBranchOnRemoteRepository).toHaveBeenCalled();
-      expect(removeTag).toHaveBeenCalled();
-      expect(removeTagOnRemoteRepository).toHaveBeenCalled();
-    });
-    it("should rollback commits, remove tags and delete release branch when pull request creation fails", async () => {
-      const { branch, cwd } = context;
-      const mockedError = new Error(
-        "Failed to create the pull request: The command failed with status 128.",
-        {
-          cause: {
-            title: "Failed to create the pull request",
-            message: "The command failed with status 128.",
-            details: {
-              output: "GitHub API error",
-              command: "POST /repos/:owner/:repo/pulls"
-            }
-          }
-        }
-      );
-      vi.mocked(createPullRequest).mockRejectedValue(mockedError);
-      await expect(publish(context)).rejects.toThrow(mockedError);
-      expect(cancelCommitsSinceRef).toHaveBeenCalledWith(
-        "0123456",
-        expect.any(String),
-        expect.any(Boolean)
-      );
-      expect(switchToBranch).toHaveBeenCalledWith(branch, cwd);
-      expect(deleteBranch).toHaveBeenCalledWith(mockedReleaseBranch, cwd, expect.any(Boolean));
-      expect(deleteBranchOnRemoteRepository).toHaveBeenCalled();
-      expect(removeTag).toHaveBeenCalled();
-      expect(removeTagOnRemoteRepository).toHaveBeenCalled();
-    });
-    it("should rollback commits, remove tags and delete release branch when release notes creation fails", async () => {
-      const { branch, cwd } = context;
-      const mockedError = new Error(
-        "Failed to create the release notes: Failed to fetch URI https://api.github.com/repos/user-id/repo-name/releases",
-        {
-          cause: {
-            title: "Failed to create the release notes",
-            message: "Failed to fetch URI https://api.github.com/repos/user-id/repo-name/releases",
-            details: {
-              output: "GitHub API error",
-              command: "POST https://api.github.com/repos/user-id/repo-name/releases"
-            }
-          }
-        }
-      );
-      vi.mocked(createReleaseNotes).mockRejectedValue(mockedError);
-      await expect(publish(context)).rejects.toThrow(mockedError);
-      expect(cancelCommitsSinceRef).toHaveBeenCalledWith(
-        "0123456",
-        expect.any(String),
-        expect.any(Boolean)
-      );
-      expect(switchToBranch).toHaveBeenCalledWith(branch, cwd);
-      expect(deleteBranch).toHaveBeenCalledWith(mockedReleaseBranch, cwd, expect.any(Boolean));
-      expect(deleteBranchOnRemoteRepository).toHaveBeenCalled();
-      expect(removeTag).toHaveBeenCalled();
-      expect(removeTagOnRemoteRepository).toHaveBeenCalled();
-    });
-    it("should not rollback when error is not from `git add`, `git commit`, `git push`, repository merge options request, pull request creation or release notes creation", async () => {
-      vi.mocked(updateLockFile).mockRejectedValue(new Error("Lock file update failed"));
-      await expect(publish(context)).rejects.toThrow();
-      expect(cancelCommitsSinceRef).not.toHaveBeenCalled();
-      expect(switchToBranch).not.toHaveBeenCalled();
-      expect(deleteBranch).not.toHaveBeenCalled();
-      expect(deleteBranchOnRemoteRepository).not.toHaveBeenCalled();
-      expect(removeTag).not.toHaveBeenCalled();
-      expect(removeTagOnRemoteRepository).not.toHaveBeenCalled();
-    });
-    it("should set `process.exitCode` to 1 on error", async () => {
-      vi.mocked(push).mockRejectedValue(new Error("Some error"));
-      await expect(publish(context)).rejects.toThrow();
-      expect(process.exitCode).toBe(1);
-    });
-    it("should create all tags before pushing", async () => {
-      const operations: string[] = [];
-      vi.mocked(createTag).mockImplementation(() => {
-        operations.push("tag");
-      });
-      vi.mocked(push).mockImplementation(async () => {
-        operations.push("push");
-      });
-      vi.mocked(createPullRequest).mockImplementation(async () => {
-        operations.push("pullRequest");
-        return mockedPullRequestReference;
-      });
-      await publish(context);
-      expect(operations.lastIndexOf("tag")).toBeLessThan(operations.indexOf("push"));
-    });
-    it("should not add to `packagePublishingSet` when `preparePublishing` returns `null`", async () => {
-      await publish(context);
-      expect(publishToRegistry).not.toHaveBeenCalled();
-    });
-    it("should collect all Git tags during package processing", async () => {
-      await publish(context);
-      const gitTags = context.nextRelease.map(packageItem => packageItem.gitTag);
-      for (const gitTag of gitTags) {
-        expect(createTag).toHaveBeenCalledWith(
-          expect.objectContaining({ gitTag }),
-          expect.any(String),
-          expect.any(Boolean)
-        );
-      }
-    });
-    it("should remove all created tags on rollback", async () => {
-      const mockedBranch = "release-change/main/1.2.3";
-      const mockedError = new Error(
-        "Failed to run the `git push` command: The command failed with status 128.",
-        {
-          cause: {
-            title: "Failed to run the `git push` command",
-            message: "The command failed with status 128.",
-            details: {
-              output: "Git error",
-              command: `git push --follow-tags origin ${mockedBranch}`
-            }
-          }
-        }
-      );
-      vi.mocked(push).mockRejectedValue(mockedError);
-      await expect(publish(context)).rejects.toThrow(mockedError);
-      expect(removeTag).toHaveBeenCalledTimes(context.nextRelease.length);
-      expect(removeTagOnRemoteRepository).toHaveBeenCalledTimes(context.nextRelease.length);
-      for (const packageNextRelease of context.nextRelease) {
-        expect(removeTag).toHaveBeenCalledWith(
-          packageNextRelease.gitTag,
-          expect.any(String),
-          expect.any(Boolean)
-        );
-        expect(removeTagOnRemoteRepository).toHaveBeenCalledWith(
-          packageNextRelease.gitTag,
-          context
-        );
-      }
-    });
-    it("should create release notes for all packages", async () => {
-      await publish(context);
-      expect(createReleaseNotes).toHaveBeenCalledTimes(context.nextRelease.length);
-    });
-    it("should create release notes after successful push", async () => {
-      const operations: string[] = [];
-      vi.mocked(push).mockImplementation(async () => {
-        operations.push("push");
-      });
-      vi.mocked(createPullRequest).mockImplementation(async () => {
-        operations.push("pullRequest");
-        return mockedPullRequestReference;
-      });
-      vi.mocked(createReleaseNotes).mockImplementation(async () => {
-        operations.push("releaseNotes");
-      });
-      await publish(context);
-      expect(operations.lastIndexOf("push")).toBeLessThan(operations.indexOf("releaseNotes"));
-    });
-    it("should handle non-Error exceptions", async () => {
-      vi.mocked(push).mockRejectedValue("String error");
-      await expect(publish(context)).rejects.toThrow("String error");
-    });
-    it("should preserve error cause when rethrowing", async () => {
-      vi.mocked(push).mockRejectedValue(new Error("Original", { cause: "custom-cause" }));
-      try {
-        await publish(context);
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error);
-        expect.objectContaining({ cause: "custom-cause" });
-      }
-    });
-  });
+  );
   it("should publish all packages that return valid publishing info", async () => {
     vi.mocked(prepareReleaseNotes).mockReturnValue(mockedReleaseNotes);
     vi.mocked(preparePublishing)

--- a/packages/release/test/set-last-release.test.ts
+++ b/packages/release/test/set-last-release.test.ts
@@ -121,64 +121,51 @@ it("should not call `getLatestValidTag()` if the package cannot publish from the
   setLastRelease(mockedContextWithIneligibleBranch);
   expect(getLatestValidTag).not.toHaveBeenCalled();
 });
-it.each(
-  mockedPackages
-)("should add the last release to the context with `packages` set with the appropriate values and `ref` set to `null` if no Git tags nor package versions are found on branch $branch", ({
-  context,
-  branch,
-  packages,
-  expectedLastReleaseWithoutAnything
-}) => {
-  const mockedContext = { ...context, branch, packages };
-  vi.mocked(getAllTags).mockReturnValue([]);
-  vi.mocked(getLatestValidTag).mockReturnValue(null);
-  vi.mocked(validate).mockReturnValue(null);
-  vi.mocked(getPackageVersion).mockReturnValue(null);
-  setLastRelease(mockedContext);
-  assert.deepEqual(mockedContext.lastRelease, expectedLastReleaseWithoutAnything);
-});
-it.each(
-  mockedPackages
-)("should add the last release to the context with `packages` set with the appropriate values and `ref` set to `null` if no Git tags are found on branch $branch, but a package version is found", ({
-  context,
-  branch,
-  packages,
-  packageVersions,
-  expectedLastReleaseWithoutGitTags
-}) => {
-  const mockedContext = { ...context, branch, packages };
-  vi.mocked(getAllTags).mockReturnValue([]);
-  vi.mocked(getLatestValidTag).mockReturnValue(null);
-  vi.mocked(getPackageVersion).mockImplementation(path => {
-    const expectedPackage = packageVersions.find(packageItem => packageItem.pathname === path);
-    return expectedPackage ? expectedPackage.version : null;
-  });
-  setLastRelease(mockedContext);
-  assert.deepEqual(mockedContext.lastRelease, expectedLastReleaseWithoutGitTags);
-});
-it.each(
-  mockedPackages
-)("should add the last release to the context with `ref` set to the Git tag value and `packages` set with the appropriate values if a Git tag is found on branch $branch (and no package versions if no Git tags are found)", ({
-  context,
-  branch,
-  packages,
-  expectedLastRelease
-}) => {
-  const mockedContext = { ...context, branch, packages };
-  vi.mocked(getAllTags).mockReturnValue(mockedGitTags);
-  vi.mocked(getLatestValidTag).mockImplementation((_context, packageName) => {
-    if (typeof packageName === "string") {
-      const expectedPackage = expectedLastRelease.packages.find(
-        packageItem => packageItem.name === packageName
-      );
-      return expectedPackage ? expectedPackage.gitTag : null;
-    }
-    return expectedLastRelease.ref;
-  });
-  vi.mocked(getVersionFromTag).mockImplementation(tag => {
-    return tag.replace(/^(@[^@]+@)?v/, "");
-  });
-  vi.mocked(getPackageVersion).mockReturnValue(null);
-  setLastRelease(mockedContext);
-  assert.deepEqual(mockedContext.lastRelease, expectedLastRelease);
-});
+it.each(mockedPackages)(
+  "should add the last release to the context with `packages` set with the appropriate values and `ref` set to `null` if no Git tags nor package versions are found on branch $branch",
+  ({ context, branch, packages, expectedLastReleaseWithoutAnything }) => {
+    const mockedContext = { ...context, branch, packages };
+    vi.mocked(getAllTags).mockReturnValue([]);
+    vi.mocked(getLatestValidTag).mockReturnValue(null);
+    vi.mocked(validate).mockReturnValue(null);
+    vi.mocked(getPackageVersion).mockReturnValue(null);
+    setLastRelease(mockedContext);
+    assert.deepEqual(mockedContext.lastRelease, expectedLastReleaseWithoutAnything);
+  }
+);
+it.each(mockedPackages)(
+  "should add the last release to the context with `packages` set with the appropriate values and `ref` set to `null` if no Git tags are found on branch $branch, but a package version is found",
+  ({ context, branch, packages, packageVersions, expectedLastReleaseWithoutGitTags }) => {
+    const mockedContext = { ...context, branch, packages };
+    vi.mocked(getAllTags).mockReturnValue([]);
+    vi.mocked(getLatestValidTag).mockReturnValue(null);
+    vi.mocked(getPackageVersion).mockImplementation(path => {
+      const expectedPackage = packageVersions.find(packageItem => packageItem.pathname === path);
+      return expectedPackage ? expectedPackage.version : null;
+    });
+    setLastRelease(mockedContext);
+    assert.deepEqual(mockedContext.lastRelease, expectedLastReleaseWithoutGitTags);
+  }
+);
+it.each(mockedPackages)(
+  "should add the last release to the context with `ref` set to the Git tag value and `packages` set with the appropriate values if a Git tag is found on branch $branch (and no package versions if no Git tags are found)",
+  ({ context, branch, packages, expectedLastRelease }) => {
+    const mockedContext = { ...context, branch, packages };
+    vi.mocked(getAllTags).mockReturnValue(mockedGitTags);
+    vi.mocked(getLatestValidTag).mockImplementation((_context, packageName) => {
+      if (typeof packageName === "string") {
+        const expectedPackage = expectedLastRelease.packages.find(
+          packageItem => packageItem.name === packageName
+        );
+        return expectedPackage ? expectedPackage.gitTag : null;
+      }
+      return expectedLastRelease.ref;
+    });
+    vi.mocked(getVersionFromTag).mockImplementation(tag => {
+      return tag.replace(/^(@[^@]+@)?v/, "");
+    });
+    vi.mocked(getPackageVersion).mockReturnValue(null);
+    setLastRelease(mockedContext);
+    assert.deepEqual(mockedContext.lastRelease, expectedLastRelease);
+  }
+);

--- a/packages/release/test/set-next-release.test.ts
+++ b/packages/release/test/set-next-release.test.ts
@@ -98,63 +98,63 @@ it("should log a warning message if no last release is found concerning the pack
   });
   expect(mockedLogger.logWarn).toHaveBeenCalledWith("No last release found for root package.");
 });
-describe.each([
-  ...mockedNextReleases,
-  ...mockedNextReleasesInMonorepo
-])("add release to context (ref: $lastRelease.ref)", ({ lastRelease, branches }) => {
-  describe.each(branches)("for branch $branch", ({ branch, releaseTypes }) => {
-    describe.each(releaseTypes)("for $releaseType", ({ releaseType, nextReleases }) => {
-      it("should set nextRelease with the appropriate values", () => {
-        const context = {
-          ...mockedContext,
-          config: { ...mockedConfig, isMonorepo: true },
-          branch,
-          lastRelease
-        };
-        const expectedNextRelease: NextRelease = nextReleases.map(nextRelease => {
-          const gitTag = `${nextRelease.name}${nextRelease.name ? "@" : ""}v${nextRelease.version}`;
-          return nextRelease.npmTag
-            ? {
-                name: nextRelease.name,
-                pathname: nextRelease.pathname,
-                gitTag,
-                version: nextRelease.version,
-                npmTag: nextRelease.npmTag
+describe.each([...mockedNextReleases, ...mockedNextReleasesInMonorepo])(
+  "add release to context (ref: $lastRelease.ref)",
+  ({ lastRelease, branches }) => {
+    describe.each(branches)("for branch $branch", ({ branch, releaseTypes }) => {
+      describe.each(releaseTypes)("for $releaseType", ({ releaseType, nextReleases }) => {
+        it("should set nextRelease with the appropriate values", () => {
+          const context = {
+            ...mockedContext,
+            config: { ...mockedConfig, isMonorepo: true },
+            branch,
+            lastRelease
+          };
+          const expectedNextRelease: NextRelease = nextReleases.map(nextRelease => {
+            const gitTag = `${nextRelease.name}${nextRelease.name ? "@" : ""}v${nextRelease.version}`;
+            return nextRelease.npmTag
+              ? {
+                  name: nextRelease.name,
+                  pathname: nextRelease.pathname,
+                  gitTag,
+                  version: nextRelease.version,
+                  npmTag: nextRelease.npmTag
+                }
+              : {
+                  name: nextRelease.name,
+                  pathname: nextRelease.pathname,
+                  gitTag,
+                  version: nextRelease.version
+                };
+          });
+          for (const releaseTypeItem of releaseType) {
+            vi.mocked(incrementVersion).mockReturnValueOnce(
+              expectedNextRelease.find(nextRelease => nextRelease.name === releaseTypeItem.name)
+                ?.version ?? ""
+            );
+          }
+          setNextRelease(releaseType, context);
+          assert.deepEqual(context.nextRelease, expectedNextRelease);
+          for (const nextRelease of nextReleases) {
+            const { name, version } = nextRelease;
+            const packageLastRelease = lastRelease.packages.find(
+              packageItem => packageItem.name === name
+            );
+            const packageName = name ? name : "root";
+            if (packageLastRelease) {
+              if (packageLastRelease.gitTag) {
+                expect(mockedLogger.logInfo).toHaveBeenCalledWith(
+                  `For ${packageName} package, the previous release is ${packageLastRelease.version} and the next release version is ${version}.`
+                );
+              } else {
+                expect(mockedLogger.logInfo).toHaveBeenCalledWith(
+                  `For ${packageName} package, there is no previous release and the next release version is ${version}.`
+                );
               }
-            : {
-                name: nextRelease.name,
-                pathname: nextRelease.pathname,
-                gitTag,
-                version: nextRelease.version
-              };
-        });
-        for (const releaseTypeItem of releaseType) {
-          vi.mocked(incrementVersion).mockReturnValueOnce(
-            expectedNextRelease.find(nextRelease => nextRelease.name === releaseTypeItem.name)
-              ?.version ?? ""
-          );
-        }
-        setNextRelease(releaseType, context);
-        assert.deepEqual(context.nextRelease, expectedNextRelease);
-        for (const nextRelease of nextReleases) {
-          const { name, version } = nextRelease;
-          const packageLastRelease = lastRelease.packages.find(
-            packageItem => packageItem.name === name
-          );
-          const packageName = name ? name : "root";
-          if (packageLastRelease) {
-            if (packageLastRelease.gitTag) {
-              expect(mockedLogger.logInfo).toHaveBeenCalledWith(
-                `For ${packageName} package, the previous release is ${packageLastRelease.version} and the next release version is ${version}.`
-              );
-            } else {
-              expect(mockedLogger.logInfo).toHaveBeenCalledWith(
-                `For ${packageName} package, there is no previous release and the next release version is ${version}.`
-              );
             }
           }
-        }
+        });
       });
     });
-  });
-});
+  }
+);

--- a/packages/release/test/update-lock-file.test.ts
+++ b/packages/release/test/update-lock-file.test.ts
@@ -45,27 +45,26 @@ describe.each(mockedNextReleases)("for $packageName", ({ packageManifestPath, ne
     await expect(updateLockFile(nextRelease, mockedContext, null)).rejects.toThrow(expectedError);
     expect(mockedCommand).toHaveBeenCalledWith("git", ["restore", packageManifestPath]);
   });
-  it.each(
-    mockedPackageManagerCommands
-  )("should not run the $command command if the lock file does not exist", async ({ command }) => {
-    vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    const mockedCommand = vi
-      .mocked(runCommand)
-      .mockResolvedValue({ status: 0, stdout: "", stderr: "" });
-    await updateLockFile(nextRelease, mockedContext, command);
-    expect(mockedCommand).not.toHaveBeenCalled();
-  });
-  it.each(
-    mockedPackageManagerCommands
-  )("should run the $command command if the package manager used is $command and the lock file exists", async ({
-    command,
-    args
-  }) => {
-    vi.spyOn(fs, "existsSync").mockReturnValue(true);
-    const mockedCommand = vi
-      .mocked(runCommand)
-      .mockResolvedValue({ status: 0, stdout: "", stderr: "" });
-    await updateLockFile(nextRelease, mockedContext, command);
-    expect(mockedCommand).toHaveBeenCalledWith(command, args);
-  });
+  it.each(mockedPackageManagerCommands)(
+    "should not run the $command command if the lock file does not exist",
+    async ({ command }) => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      const mockedCommand = vi
+        .mocked(runCommand)
+        .mockResolvedValue({ status: 0, stdout: "", stderr: "" });
+      await updateLockFile(nextRelease, mockedContext, command);
+      expect(mockedCommand).not.toHaveBeenCalled();
+    }
+  );
+  it.each(mockedPackageManagerCommands)(
+    "should run the $command command if the package manager used is $command and the lock file exists",
+    async ({ command, args }) => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(true);
+      const mockedCommand = vi
+        .mocked(runCommand)
+        .mockResolvedValue({ status: 0, stdout: "", stderr: "" });
+      await updateLockFile(nextRelease, mockedContext, command);
+      expect(mockedCommand).toHaveBeenCalledWith(command, args);
+    }
+  );
 });

--- a/packages/release/test/update-package-dependencies-versions.test.ts
+++ b/packages/release/test/update-package-dependencies-versions.test.ts
@@ -25,96 +25,99 @@ beforeEach(() => {
   vi.spyOn(fs, "existsSync").mockReturnValue(true);
 });
 
-describe.each(
-  mockedNextReleasesWithDependencies
-)("for $packageName (update method: $dependencyUpdateMethod)", ({
-  packageName,
-  packageManifestPath,
-  nextRelease,
-  dependencyUpdateMethod,
-  dependencies,
-  expectedDependenciesUpdates,
-  packageManifest,
-  expectedPackageManifest
-}) => {
-  it("should throw an error if `dependencyUpdateMethod` is not defined", () => {
-    const expectedError = new Error(
-      "Failed to update the package dependencies versions: Dependency update method not found.",
-      {
-        cause: {
-          title: "Failed to update the package dependencies versions",
-          message: "Dependency update method not found.",
-          details: {
-            output: "dependencyUpdateMethod: undefined"
+describe.each(mockedNextReleasesWithDependencies)(
+  "for $packageName (update method: $dependencyUpdateMethod)",
+  ({
+    packageName,
+    packageManifestPath,
+    nextRelease,
+    dependencyUpdateMethod,
+    dependencies,
+    expectedDependenciesUpdates,
+    packageManifest,
+    expectedPackageManifest
+  }) => {
+    it("should throw an error if `dependencyUpdateMethod` is not defined", () => {
+      const expectedError = new Error(
+        "Failed to update the package dependencies versions: Dependency update method not found.",
+        {
+          cause: {
+            title: "Failed to update the package dependencies versions",
+            message: "Dependency update method not found.",
+            details: {
+              output: "dependencyUpdateMethod: undefined"
+            }
           }
         }
-      }
-    );
-    vi.mocked(formatDetailedError).mockReturnValue(expectedError);
-    expect(() => updatePackageDependenciesVersions(nextRelease, [], mockedContext)).toThrow(
-      expectedError
-    );
-  });
-  it("should throw an error if the package manifest is not found", () => {
-    const expectedError = new Error(
-      `Failed to update the package dependencies versions: Package ${packageManifestPath} not found for ${packageName}.`,
-      {
-        cause: {
-          title: "Failed to update the package dependencies versions",
-          message: `Package ${packageManifestPath} not found for ${packageName}.`,
-          details: {
-            output: `fs.existsSync(${packageManifestPath}): false`
-          }
-        }
-      }
-    );
-    vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    vi.mocked(formatDetailedError).mockReturnValue(expectedError);
-    expect(() =>
-      updatePackageDependenciesVersions(nextRelease, [], {
-        ...mockedContextInMonorepo,
-        config: { ...mockedConfig, dependencyUpdateMethod: "pin" }
-      })
-    ).toThrow(expectedError);
-  });
-  it("should update the package dependencies versions", () => {
-    const readFileSpy = vi
-      .spyOn(fs, "readFileSync")
-      .mockReturnValue(JSON.stringify(packageManifest));
-    updatePackageDependenciesVersions(nextRelease, dependencies, {
-      ...mockedContextInMonorepo,
-      config: { ...mockedConfig, dependencyUpdateMethod }
-    });
-    expect(readFileSpy).toHaveBeenCalledWith(packageManifestPath, "utf-8");
-    for (const dependency of dependencies) {
-      const { name } = dependency;
-      const expectedVersion =
-        expectedDependenciesUpdates.find(
-          expectedDependencyUpdate => expectedDependencyUpdate.name === name
-        )?.version ?? null;
-      const expectedRange =
-        dependencyUpdateMethod === "caret-range"
-          ? "^"
-          : dependencyUpdateMethod === "tilde-range"
-            ? "~"
-            : "";
-      const { dependencies, devDependencies } = expectedPackageManifest;
-      if (dependencies && expectedPackageManifest.dependencies && name in dependencies) {
-        expect(expectedPackageManifest.dependencies[name]).toBe(expectedRange + expectedVersion);
-      } else if (
-        devDependencies &&
-        expectedPackageManifest.devDependencies &&
-        name in devDependencies
-      ) {
-        expect(expectedPackageManifest.devDependencies[name]).toBe(expectedRange + expectedVersion);
-      }
-      expect(mockedLogger.logInfo).toHaveBeenCalledWith(
-        `Package version updated to ${expectedVersion} for package dependency ${name} in ${packageName}.`
       );
-    }
-    expect(fs.writeFileSync).toHaveBeenCalledWith(
-      packageManifestPath,
-      `${JSON.stringify(expectedPackageManifest, null, 2)}\n`
-    );
-  });
-});
+      vi.mocked(formatDetailedError).mockReturnValue(expectedError);
+      expect(() => updatePackageDependenciesVersions(nextRelease, [], mockedContext)).toThrow(
+        expectedError
+      );
+    });
+    it("should throw an error if the package manifest is not found", () => {
+      const expectedError = new Error(
+        `Failed to update the package dependencies versions: Package ${packageManifestPath} not found for ${packageName}.`,
+        {
+          cause: {
+            title: "Failed to update the package dependencies versions",
+            message: `Package ${packageManifestPath} not found for ${packageName}.`,
+            details: {
+              output: `fs.existsSync(${packageManifestPath}): false`
+            }
+          }
+        }
+      );
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      vi.mocked(formatDetailedError).mockReturnValue(expectedError);
+      expect(() =>
+        updatePackageDependenciesVersions(nextRelease, [], {
+          ...mockedContextInMonorepo,
+          config: { ...mockedConfig, dependencyUpdateMethod: "pin" }
+        })
+      ).toThrow(expectedError);
+    });
+    it("should update the package dependencies versions", () => {
+      const readFileSpy = vi
+        .spyOn(fs, "readFileSync")
+        .mockReturnValue(JSON.stringify(packageManifest));
+      updatePackageDependenciesVersions(nextRelease, dependencies, {
+        ...mockedContextInMonorepo,
+        config: { ...mockedConfig, dependencyUpdateMethod }
+      });
+      expect(readFileSpy).toHaveBeenCalledWith(packageManifestPath, "utf-8");
+      for (const dependency of dependencies) {
+        const { name } = dependency;
+        const expectedVersion =
+          expectedDependenciesUpdates.find(
+            expectedDependencyUpdate => expectedDependencyUpdate.name === name
+          )?.version ?? null;
+        const expectedRange =
+          dependencyUpdateMethod === "caret-range"
+            ? "^"
+            : dependencyUpdateMethod === "tilde-range"
+              ? "~"
+              : "";
+        const { dependencies, devDependencies } = expectedPackageManifest;
+        if (dependencies && expectedPackageManifest.dependencies && name in dependencies) {
+          expect(expectedPackageManifest.dependencies[name]).toBe(expectedRange + expectedVersion);
+        } else if (
+          devDependencies &&
+          expectedPackageManifest.devDependencies &&
+          name in devDependencies
+        ) {
+          expect(expectedPackageManifest.devDependencies[name]).toBe(
+            expectedRange + expectedVersion
+          );
+        }
+        expect(mockedLogger.logInfo).toHaveBeenCalledWith(
+          `Package version updated to ${expectedVersion} for package dependency ${name} in ${packageName}.`
+        );
+      }
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        packageManifestPath,
+        `${JSON.stringify(expectedPackageManifest, null, 2)}\n`
+      );
+    });
+  }
+);

--- a/packages/release/test/update-package-version.test.ts
+++ b/packages/release/test/update-package-version.test.ts
@@ -41,47 +41,46 @@ beforeEach(() => {
   vi.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify(mockedPackageManifest));
 });
 
-describe.each(mockedNextReleases)("for $packageName", ({
-  packageName,
-  packageManifestPath,
-  nextRelease
-}) => {
-  it("should throw an error if the package manifest is not found", () => {
-    const expectedError = new Error(
-      `Failed to update the package version: Package ${packageManifestPath} not found for ${packageName}.`,
-      {
-        cause: {
-          title: "Failed to update the package version",
-          message: `Package ${packageManifestPath} not found for ${packageName}.`,
-          details: {
-            output: `fs.existsSync(${packageManifestPath}): false`
+describe.each(mockedNextReleases)(
+  "for $packageName",
+  ({ packageName, packageManifestPath, nextRelease }) => {
+    it("should throw an error if the package manifest is not found", () => {
+      const expectedError = new Error(
+        `Failed to update the package version: Package ${packageManifestPath} not found for ${packageName}.`,
+        {
+          cause: {
+            title: "Failed to update the package version",
+            message: `Package ${packageManifestPath} not found for ${packageName}.`,
+            details: {
+              output: `fs.existsSync(${packageManifestPath}): false`
+            }
           }
         }
+      );
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      vi.mocked(formatDetailedError).mockReturnValue(expectedError);
+      expect(() => updatePackageVersion(nextRelease, mockedContextWithNextRelease)).toThrow(
+        expectedError
+      );
+    });
+    it.each([mockedPackageManifest, mockedPrivatePackageManifest])(
+      "should update the package version",
+      packageManifest => {
+        const expectedVersion = nextRelease.version;
+        const expectedContent = `${JSON.stringify(
+          { ...packageManifest, version: expectedVersion },
+          null,
+          2
+        )}\n`;
+        const readFileSpy = vi.spyOn(fs, "readFileSync").mockReturnValue(expectedContent);
+        updatePackageVersion(nextRelease, mockedContextWithNextRelease);
+        expect(readFileSpy).toHaveBeenCalledWith(packageManifestPath, "utf-8");
+        expect(JSON.parse(expectedContent).version).toBe(expectedVersion);
+        expect(fs.writeFileSync).toHaveBeenCalledWith(packageManifestPath, expectedContent);
+        expect(mockedLogger.logInfo).toHaveBeenCalledWith(
+          `Package version updated to ${expectedVersion} for ${packageName}.`
+        );
       }
     );
-    vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    vi.mocked(formatDetailedError).mockReturnValue(expectedError);
-    expect(() => updatePackageVersion(nextRelease, mockedContextWithNextRelease)).toThrow(
-      expectedError
-    );
-  });
-  it.each([
-    mockedPackageManifest,
-    mockedPrivatePackageManifest
-  ])("should update the package version", packageManifest => {
-    const expectedVersion = nextRelease.version;
-    const expectedContent = `${JSON.stringify(
-      { ...packageManifest, version: expectedVersion },
-      null,
-      2
-    )}\n`;
-    const readFileSpy = vi.spyOn(fs, "readFileSync").mockReturnValue(expectedContent);
-    updatePackageVersion(nextRelease, mockedContextWithNextRelease);
-    expect(readFileSpy).toHaveBeenCalledWith(packageManifestPath, "utf-8");
-    expect(JSON.parse(expectedContent).version).toBe(expectedVersion);
-    expect(fs.writeFileSync).toHaveBeenCalledWith(packageManifestPath, expectedContent);
-    expect(mockedLogger.logInfo).toHaveBeenCalledWith(
-      `Package version updated to ${expectedVersion} for ${packageName}.`
-    );
-  });
-});
+  }
+);

--- a/packages/semver/test/classes/comparator.test.ts
+++ b/packages/semver/test/classes/comparator.test.ts
@@ -26,37 +26,41 @@ test("any versions should match anything", () => {
 test("'=' should be ignored", () => {
   assert.deepEqual(new Comparator("=1.2.3"), new Comparator("1.2.3"));
 });
-it.each(
-  comparatorIntersections
-)("should return `$2` when $0 intersects $1", (comparator1, comparator2, expected, options) => {
-  expect(new Comparator(comparator1).intersects(new Comparator(comparator2), options)).toBe(
-    expected
-  );
-});
-it.each(
-  comparatorIntersections
-)("should return `$2` when $1 intersects $0", (comparator1, comparator2, expected, options) => {
-  expect(new Comparator(comparator2).intersects(new Comparator(comparator1), options)).toBe(
-    expected
-  );
-});
-it.each(
-  comparatorIntersectionsInLooseMode
-)("should return `$2` when $0 intersects $1 in loose mode", (comparator1, comparator2, expected, options) => {
-  expect(
-    new Comparator(comparator1, { loose: true }).intersects(
-      new Comparator(comparator2, { loose: true }),
-      options
-    )
-  ).toBe(expected);
-});
-it.each(
-  comparatorIntersectionsInLooseMode
-)("should return `$2` when $1 intersects $0 in loose mode", (comparator1, comparator2, expected, options) => {
-  expect(
-    new Comparator(comparator2, { loose: true }).intersects(
-      new Comparator(comparator1, { loose: true }),
-      options
-    )
-  ).toBe(expected);
-});
+it.each(comparatorIntersections)(
+  "should return `$2` when $0 intersects $1",
+  (comparator1, comparator2, expected, options) => {
+    expect(new Comparator(comparator1).intersects(new Comparator(comparator2), options)).toBe(
+      expected
+    );
+  }
+);
+it.each(comparatorIntersections)(
+  "should return `$2` when $1 intersects $0",
+  (comparator1, comparator2, expected, options) => {
+    expect(new Comparator(comparator2).intersects(new Comparator(comparator1), options)).toBe(
+      expected
+    );
+  }
+);
+it.each(comparatorIntersectionsInLooseMode)(
+  "should return `$2` when $0 intersects $1 in loose mode",
+  (comparator1, comparator2, expected, options) => {
+    expect(
+      new Comparator(comparator1, { loose: true }).intersects(
+        new Comparator(comparator2, { loose: true }),
+        options
+      )
+    ).toBe(expected);
+  }
+);
+it.each(comparatorIntersectionsInLooseMode)(
+  "should return `$2` when $1 intersects $0 in loose mode",
+  (comparator1, comparator2, expected, options) => {
+    expect(
+      new Comparator(comparator2, { loose: true }).intersects(
+        new Comparator(comparator1, { loose: true }),
+        options
+      )
+    ).toBe(expected);
+  }
+);

--- a/packages/semver/test/classes/range.test.ts
+++ b/packages/semver/test/classes/range.test.ts
@@ -6,52 +6,47 @@ import { rangeIntersections } from "../fixtures/range-intersections.js";
 import { validRanges } from "../fixtures/valid-ranges.js";
 import { validRangesInLooseMode } from "../fixtures/valid-ranges-in-loose-mode.js";
 
-it.each(invalidRanges)("should throw an error if the range $raw is invalid", ({
-  raw,
-  error,
-  options
-}) => {
-  expect(() => new Range(raw, options)).toThrow(error);
-});
-it.each(
-  validRangesInLooseMode
-)("should throw an error if the range $raw is parsed in strict mode", ({
-  raw,
-  includePrerelease
-}) => {
-  expect(() => new Range(raw, { includePrerelease })).toThrow();
-});
-it.each(
-  validRangesInLooseMode
-)("should create a `Range` object from the range $raw in loose mode", ({
-  raw,
-  expected,
-  includePrerelease
-}) => {
-  const { range } = expected;
-  const result = new Range(raw, { loose: true, includePrerelease });
-  assert.strictEqual(result.raw, raw);
-  assert.strictEqual(result.range, range);
-  assert.strictEqual(result.includePrerelease, Boolean(includePrerelease));
-});
-it.each(validRanges)("should create a `Range` object from the valid range $raw", ({
-  raw,
-  expected,
-  includePrerelease
-}) => {
-  const { range } = expected;
-  const result = new Range(raw, { includePrerelease });
-  assert.strictEqual(result.raw, raw);
-  assert.strictEqual(result.range, range);
-  assert.strictEqual(result.includePrerelease, Boolean(includePrerelease));
-});
-it.each(
-  rangeIntersections
-)("should return `$2` when $0 intersects $1", (range1, range2, expected) => {
-  expect(new Range(range1).intersects(new Range(range2))).toBe(expected);
-});
-it.each(
-  rangeIntersections
-)("should return `$2` when $1 intersects $0", (range1, range2, expected) => {
-  expect(new Range(range2).intersects(new Range(range1))).toBe(expected);
-});
+it.each(invalidRanges)(
+  "should throw an error if the range $raw is invalid",
+  ({ raw, error, options }) => {
+    expect(() => new Range(raw, options)).toThrow(error);
+  }
+);
+it.each(validRangesInLooseMode)(
+  "should throw an error if the range $raw is parsed in strict mode",
+  ({ raw, includePrerelease }) => {
+    expect(() => new Range(raw, { includePrerelease })).toThrow();
+  }
+);
+it.each(validRangesInLooseMode)(
+  "should create a `Range` object from the range $raw in loose mode",
+  ({ raw, expected, includePrerelease }) => {
+    const { range } = expected;
+    const result = new Range(raw, { loose: true, includePrerelease });
+    assert.strictEqual(result.raw, raw);
+    assert.strictEqual(result.range, range);
+    assert.strictEqual(result.includePrerelease, Boolean(includePrerelease));
+  }
+);
+it.each(validRanges)(
+  "should create a `Range` object from the valid range $raw",
+  ({ raw, expected, includePrerelease }) => {
+    const { range } = expected;
+    const result = new Range(raw, { includePrerelease });
+    assert.strictEqual(result.raw, raw);
+    assert.strictEqual(result.range, range);
+    assert.strictEqual(result.includePrerelease, Boolean(includePrerelease));
+  }
+);
+it.each(rangeIntersections)(
+  "should return `$2` when $0 intersects $1",
+  (range1, range2, expected) => {
+    expect(new Range(range1).intersects(new Range(range2))).toBe(expected);
+  }
+);
+it.each(rangeIntersections)(
+  "should return `$2` when $1 intersects $0",
+  (range1, range2, expected) => {
+    expect(new Range(range2).intersects(new Range(range1))).toBe(expected);
+  }
+);

--- a/packages/semver/test/classes/semver.test.ts
+++ b/packages/semver/test/classes/semver.test.ts
@@ -8,104 +8,83 @@ import { validIncrementsInLooseMode } from "../fixtures/valid-increments-in-loos
 import { validVersions } from "../fixtures/valid-versions.js";
 import { validVersionsInLooseMode } from "../fixtures/valid-versions-in-loose-mode.js";
 
-it.each(invalidVersions)("should throw an error if the version $raw is invalid", ({
-  raw,
-  error,
-  options
-}) => {
-  expect(() => new Semver(raw, options)).toThrow(error);
-});
-it.each(
-  validVersionsInLooseMode
-)("should throw an error if the version $raw is parsed in strict mode", ({ raw }) => {
-  expect(() => new Semver(raw)).toThrow(`Invalid version \`${raw}\`.`);
-});
-it.each(
-  validVersionsInLooseMode
-)("should create a `Semver` object from the version $raw in loose mode", ({
-  raw,
-  version,
-  expected
-}) => {
-  const { major, minor, patch, prerelease, build } = expected;
-  const result = new Semver(raw, { loose: true });
-  assert.strictEqual(result.raw, raw);
-  assert.strictEqual(result.version, version);
-  assert.strictEqual(result.major, major);
-  assert.strictEqual(result.minor, minor);
-  assert.strictEqual(result.patch, patch);
-  assert.deepEqual(result.prerelease, prerelease);
-  assert.deepEqual(result.build, build);
-});
-it.each(validVersions)("should create a `Semver` object from the valid version $raw", ({
-  raw,
-  version,
-  expected
-}) => {
-  const { major, minor, patch, prerelease, build } = expected;
-  const result = new Semver(raw);
-  assert.strictEqual(result.raw, raw);
-  assert.strictEqual(result.version, version);
-  assert.strictEqual(result.major, major);
-  assert.strictEqual(result.minor, minor);
-  assert.strictEqual(result.patch, patch);
-  assert.deepEqual(result.prerelease, prerelease);
-  assert.deepEqual(result.build, build);
-});
+it.each(invalidVersions)(
+  "should throw an error if the version $raw is invalid",
+  ({ raw, error, options }) => {
+    expect(() => new Semver(raw, options)).toThrow(error);
+  }
+);
+it.each(validVersionsInLooseMode)(
+  "should throw an error if the version $raw is parsed in strict mode",
+  ({ raw }) => {
+    expect(() => new Semver(raw)).toThrow(`Invalid version \`${raw}\`.`);
+  }
+);
+it.each(validVersionsInLooseMode)(
+  "should create a `Semver` object from the version $raw in loose mode",
+  ({ raw, version, expected }) => {
+    const { major, minor, patch, prerelease, build } = expected;
+    const result = new Semver(raw, { loose: true });
+    assert.strictEqual(result.raw, raw);
+    assert.strictEqual(result.version, version);
+    assert.strictEqual(result.major, major);
+    assert.strictEqual(result.minor, minor);
+    assert.strictEqual(result.patch, patch);
+    assert.deepEqual(result.prerelease, prerelease);
+    assert.deepEqual(result.build, build);
+  }
+);
+it.each(validVersions)(
+  "should create a `Semver` object from the valid version $raw",
+  ({ raw, version, expected }) => {
+    const { major, minor, patch, prerelease, build } = expected;
+    const result = new Semver(raw);
+    assert.strictEqual(result.raw, raw);
+    assert.strictEqual(result.version, version);
+    assert.strictEqual(result.major, major);
+    assert.strictEqual(result.minor, minor);
+    assert.strictEqual(result.patch, patch);
+    assert.deepEqual(result.prerelease, prerelease);
+    assert.deepEqual(result.build, build);
+  }
+);
 it("should not convert big number prerelease values as numbers", () => {
   const result = new Semver(`1.2.3-beta.${Number.MAX_SAFE_INTEGER}0`);
   assert.deepEqual(result.prerelease, ["beta", "90071992547409910"]);
 });
-it.each(
-  invalidIncrements
-)("should throw an error if the version $version is invalid to be increased", ({
-  version,
-  releaseType,
-  prefix,
-  identifierBase,
-  errorMessage
-}) => {
-  expect(() => new Semver(version).increase(releaseType, { prefix, identifierBase })).toThrow(
-    errorMessage
-  );
-});
-it.each(
-  validIncrementsInLooseMode
-)("should throw an error if the version $version is invalid to be increased in strict mode", ({
-  version,
-  releaseType,
-  prefix,
-  identifierBase
-}) => {
-  expect(() => new Semver(version).increase(releaseType, { prefix, identifierBase })).toThrow(
-    `Invalid version \`${version}\`.`
-  );
-});
-it.each(validIncrements)("should increase $version to $expected.version ($releaseType)", ({
-  version,
-  releaseType,
-  expected,
-  prefix,
-  identifierBase
-}) => {
-  const result = new Semver(version).increase(releaseType, {
-    prefix,
-    identifierBase
-  });
-  assert.deepEqual(result, expected);
-});
-it.each(
-  validIncrementsInLooseMode
-)("should increase $version to $expected.version in loose mode ($releaseType)", ({
-  version,
-  releaseType,
-  expected,
-  prefix,
-  identifierBase
-}) => {
-  const result = new Semver(version, { loose: true }).increase(releaseType, {
-    prefix,
-    identifierBase
-  });
-  assert.deepEqual(result, expected);
-});
+it.each(invalidIncrements)(
+  "should throw an error if the version $version is invalid to be increased",
+  ({ version, releaseType, prefix, identifierBase, errorMessage }) => {
+    expect(() => new Semver(version).increase(releaseType, { prefix, identifierBase })).toThrow(
+      errorMessage
+    );
+  }
+);
+it.each(validIncrementsInLooseMode)(
+  "should throw an error if the version $version is invalid to be increased in strict mode",
+  ({ version, releaseType, prefix, identifierBase }) => {
+    expect(() => new Semver(version).increase(releaseType, { prefix, identifierBase })).toThrow(
+      `Invalid version \`${version}\`.`
+    );
+  }
+);
+it.each(validIncrements)(
+  "should increase $version to $expected.version ($releaseType)",
+  ({ version, releaseType, expected, prefix, identifierBase }) => {
+    const result = new Semver(version).increase(releaseType, {
+      prefix,
+      identifierBase
+    });
+    assert.deepEqual(result, expected);
+  }
+);
+it.each(validIncrementsInLooseMode)(
+  "should increase $version to $expected.version in loose mode ($releaseType)",
+  ({ version, releaseType, expected, prefix, identifierBase }) => {
+    const result = new Semver(version, { loose: true }).increase(releaseType, {
+      prefix,
+      identifierBase
+    });
+    assert.deepEqual(result, expected);
+  }
+);

--- a/packages/semver/test/compare-build.test.ts
+++ b/packages/semver/test/compare-build.test.ts
@@ -6,23 +6,23 @@ import { comparisonsWithBuildInLooseMode } from "./fixtures/comparisons-with-bui
 import { equalitiesWithBuild } from "./fixtures/equalities-with-build.js";
 import { equalitiesWithBuildInLooseMode } from "./fixtures/equalities-with-build-in-loose-mode.js";
 
-it.each([
-  ...comparisonsWithBuildInLooseMode,
-  ...equalitiesWithBuildInLooseMode
-])("should throw an error if $a and $b are compared in strict mode", ({ a, b }) => {
-  expect(() => compareBuild(a, b)).toThrow();
-});
+it.each([...comparisonsWithBuildInLooseMode, ...equalitiesWithBuildInLooseMode])(
+  "should throw an error if $a and $b are compared in strict mode",
+  ({ a, b }) => {
+    expect(() => compareBuild(a, b)).toThrow();
+  }
+);
 it.each(comparisonsWithBuild)("$a should be greater than $b", ({ a, b }) => {
   expect(compareBuild(a, b)).toBe(1);
   expect(compareBuild(b, a)).toBe(-1);
 });
-it.each(comparisonsWithBuildInLooseMode)("$a should be greater than $b in loose mode", ({
-  a,
-  b
-}) => {
-  expect(compareBuild(a, b, { loose: true })).toBe(1);
-  expect(compareBuild(b, a, { loose: true })).toBe(-1);
-});
+it.each(comparisonsWithBuildInLooseMode)(
+  "$a should be greater than $b in loose mode",
+  ({ a, b }) => {
+    expect(compareBuild(a, b, { loose: true })).toBe(1);
+    expect(compareBuild(b, a, { loose: true })).toBe(-1);
+  }
+);
 it.each(equalitiesWithBuild)("$a should be equal to $b", ({ a, b }) => {
   expect(compareBuild(a, b)).toBe(0);
 });

--- a/packages/semver/test/compare-loose.test.ts
+++ b/packages/semver/test/compare-loose.test.ts
@@ -6,16 +6,16 @@ import { comparisonsInLooseMode } from "./fixtures/comparisons-in-loose-mode.js"
 import { equalities } from "./fixtures/equalities.js";
 import { equalitiesInLooseMode } from "./fixtures/equalities-in-loose-mode.js";
 
-test.each([
-  ...comparisons,
-  ...comparisonsInLooseMode
-])("$a should be greater than $b in loose mode", ({ a, b }) => {
-  expect(compareLoose(a, b)).toBe(1);
-  expect(compareLoose(b, a)).toBe(-1);
-});
-test.each([...equalities, ...equalitiesInLooseMode])("$a should be equal to $b in loose mode", ({
-  a,
-  b
-}) => {
-  expect(compareLoose(a, b)).toBe(0);
-});
+test.each([...comparisons, ...comparisonsInLooseMode])(
+  "$a should be greater than $b in loose mode",
+  ({ a, b }) => {
+    expect(compareLoose(a, b)).toBe(1);
+    expect(compareLoose(b, a)).toBe(-1);
+  }
+);
+test.each([...equalities, ...equalitiesInLooseMode])(
+  "$a should be equal to $b in loose mode",
+  ({ a, b }) => {
+    expect(compareLoose(a, b)).toBe(0);
+  }
+);

--- a/packages/semver/test/compare-with-operator.test.ts
+++ b/packages/semver/test/compare-with-operator.test.ts
@@ -32,12 +32,12 @@ const strictInequalities = [
 ];
 
 describe.each(nonStrictOperators)("try to compare a and b with %s", operator => {
-  it.each([
-    ...comparisonsInLooseMode,
-    ...equalitiesInLooseMode
-  ])("should throw an error if $a and $b are compared in strict mode", ({ a, b }) => {
-    expect(() => compareWithOperator(a, operator, b)).toThrow();
-  });
+  it.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+    "should throw an error if $a and $b are compared in strict mode",
+    ({ a, b }) => {
+      expect(() => compareWithOperator(a, operator, b)).toThrow();
+    }
+  );
 });
 test.each(strictEqualities)("$a and $b should match the operator ===", ({ a, b }) => {
   expect(compareWithOperator(a, "===", b)).toBe(true);
@@ -58,17 +58,18 @@ describe.each(equalityOperators)("compare a and b with %s", operator => {
   test.each(comparisons)("$a and $b should not match the operator $operator", ({ a, b }) => {
     expect(compareWithOperator(a, operator, b)).toBe(false);
   });
-  test.each(equalitiesInLooseMode)("$a and $b should match the operator $operator in loose mode", ({
-    a,
-    b
-  }) => {
-    expect(compareWithOperator(a, operator, b, { loose: true })).toBe(true);
-  });
-  test.each(
-    comparisonsInLooseMode
-  )("$a and $b should not match the operator $operator in loose mode", ({ a, b }) => {
-    expect(compareWithOperator(a, operator, b, { loose: true })).toBe(false);
-  });
+  test.each(equalitiesInLooseMode)(
+    "$a and $b should match the operator $operator in loose mode",
+    ({ a, b }) => {
+      expect(compareWithOperator(a, operator, b, { loose: true })).toBe(true);
+    }
+  );
+  test.each(comparisonsInLooseMode)(
+    "$a and $b should not match the operator $operator in loose mode",
+    ({ a, b }) => {
+      expect(compareWithOperator(a, operator, b, { loose: true })).toBe(false);
+    }
+  );
 });
 test.each(comparisons)("$a and $b should match the operator !=", ({ a, b }) => {
   expect(compareWithOperator(a, "!=", b)).toBe(true);
@@ -76,93 +77,93 @@ test.each(comparisons)("$a and $b should match the operator !=", ({ a, b }) => {
 test.each(equalities)("$a and $b should not match the operator !=", ({ a, b }) => {
   expect(compareWithOperator(a, "!=", b)).toBe(false);
 });
-test.each(comparisonsInLooseMode)("$a and $b should match the operator != in loose mode", ({
-  a,
-  b
-}) => {
-  expect(compareWithOperator(a, "!=", b, { loose: true })).toBe(true);
-});
-test.each(equalitiesInLooseMode)("$a and $b should not match the operator != in loose mode", ({
-  a,
-  b
-}) => {
-  expect(compareWithOperator(a, "!=", b, { loose: true })).toBe(false);
-});
+test.each(comparisonsInLooseMode)(
+  "$a and $b should match the operator != in loose mode",
+  ({ a, b }) => {
+    expect(compareWithOperator(a, "!=", b, { loose: true })).toBe(true);
+  }
+);
+test.each(equalitiesInLooseMode)(
+  "$a and $b should not match the operator != in loose mode",
+  ({ a, b }) => {
+    expect(compareWithOperator(a, "!=", b, { loose: true })).toBe(false);
+  }
+);
 test.each(comparisons)("$a and $b should match the operator >", ({ a, b }) => {
   expect(compareWithOperator(a, ">", b)).toBe(true);
 });
-test.each([...comparisons, ...equalities])("$a and $b should not match the operator >", ({
-  a,
-  b
-}) => {
-  expect(compareWithOperator(b, ">", a)).toBe(false);
-});
-test.each(comparisonsInLooseMode)("$a and $b should match the operator > in loose mode", ({
-  a,
-  b
-}) => {
-  expect(compareWithOperator(a, ">", b, { loose: true })).toBe(true);
-});
-test.each([
-  ...comparisonsInLooseMode,
-  ...equalitiesInLooseMode
-])("$a and $b should not match the operator > in loose mode", ({ a, b }) => {
-  expect(compareWithOperator(b, ">", a, { loose: true })).toBe(false);
-});
+test.each([...comparisons, ...equalities])(
+  "$a and $b should not match the operator >",
+  ({ a, b }) => {
+    expect(compareWithOperator(b, ">", a)).toBe(false);
+  }
+);
+test.each(comparisonsInLooseMode)(
+  "$a and $b should match the operator > in loose mode",
+  ({ a, b }) => {
+    expect(compareWithOperator(a, ">", b, { loose: true })).toBe(true);
+  }
+);
+test.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+  "$a and $b should not match the operator > in loose mode",
+  ({ a, b }) => {
+    expect(compareWithOperator(b, ">", a, { loose: true })).toBe(false);
+  }
+);
 test.each([...comparisons, ...equalities])("$a and $b should match the operator >=", ({ a, b }) => {
   expect(compareWithOperator(a, ">=", b)).toBe(true);
 });
 test.each(comparisons)("$a and $b should not match the operator >=", ({ a, b }) => {
   expect(compareWithOperator(b, ">=", a)).toBe(false);
 });
-test.each([
-  ...comparisonsInLooseMode,
-  ...equalitiesInLooseMode
-])("$a and $b should match the operator >= in loose mode", ({ a, b }) => {
-  expect(compareWithOperator(a, ">=", b, { loose: true })).toBe(true);
-});
-test.each(comparisonsInLooseMode)("$a and $b should not match the operator >= in loose mode", ({
-  a,
-  b
-}) => {
-  expect(compareWithOperator(b, ">=", a, { loose: true })).toBe(false);
-});
+test.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+  "$a and $b should match the operator >= in loose mode",
+  ({ a, b }) => {
+    expect(compareWithOperator(a, ">=", b, { loose: true })).toBe(true);
+  }
+);
+test.each(comparisonsInLooseMode)(
+  "$a and $b should not match the operator >= in loose mode",
+  ({ a, b }) => {
+    expect(compareWithOperator(b, ">=", a, { loose: true })).toBe(false);
+  }
+);
 test.each(comparisons)("$a and $b should match the operator <", ({ a, b }) => {
   expect(compareWithOperator(b, "<", a)).toBe(true);
 });
-test.each([...comparisons, ...equalities])("$a and $b should not match the operator <", ({
-  a,
-  b
-}) => {
-  expect(compareWithOperator(a, "<", b)).toBe(false);
-});
-test.each(comparisonsInLooseMode)("$a and $b should match the operator < in loose mode", ({
-  a,
-  b
-}) => {
-  expect(compareWithOperator(b, "<", a, { loose: true })).toBe(true);
-});
-test.each([
-  ...comparisonsInLooseMode,
-  ...equalitiesInLooseMode
-])("$a and $b should not match the operator < in loose mode", ({ a, b }) => {
-  expect(compareWithOperator(a, "<", b, { loose: true })).toBe(false);
-});
+test.each([...comparisons, ...equalities])(
+  "$a and $b should not match the operator <",
+  ({ a, b }) => {
+    expect(compareWithOperator(a, "<", b)).toBe(false);
+  }
+);
+test.each(comparisonsInLooseMode)(
+  "$a and $b should match the operator < in loose mode",
+  ({ a, b }) => {
+    expect(compareWithOperator(b, "<", a, { loose: true })).toBe(true);
+  }
+);
+test.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+  "$a and $b should not match the operator < in loose mode",
+  ({ a, b }) => {
+    expect(compareWithOperator(a, "<", b, { loose: true })).toBe(false);
+  }
+);
 test.each([...comparisons, ...equalities])("$a and $b should match the operator <=", ({ a, b }) => {
   expect(compareWithOperator(b, "<=", a)).toBe(true);
 });
 test.each(comparisons)("$a and $b should not match the operator <=", ({ a, b }) => {
   expect(compareWithOperator(a, "<=", b)).toBe(false);
 });
-test.each([
-  ...comparisonsInLooseMode,
-  ...equalitiesInLooseMode
-])("$a and $b should match the operator <= in loose mode", ({ a, b }) => {
-  expect(compareWithOperator(b, "<=", a, { loose: true })).toBe(true);
-});
-test.each(comparisonsInLooseMode)("$a and $b should not match the operator <= in loose mode", ({
-  a,
-  b
-}) => {
-  expect(compareWithOperator(a, "<=", b, { loose: true })).toBe(false);
-});
+test.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+  "$a and $b should match the operator <= in loose mode",
+  ({ a, b }) => {
+    expect(compareWithOperator(b, "<=", a, { loose: true })).toBe(true);
+  }
+);
+test.each(comparisonsInLooseMode)(
+  "$a and $b should not match the operator <= in loose mode",
+  ({ a, b }) => {
+    expect(compareWithOperator(a, "<=", b, { loose: true })).toBe(false);
+  }
+);

--- a/packages/semver/test/compare.test.ts
+++ b/packages/semver/test/compare.test.ts
@@ -6,12 +6,12 @@ import { comparisonsInLooseMode } from "./fixtures/comparisons-in-loose-mode.js"
 import { equalities } from "./fixtures/equalities.js";
 import { equalitiesInLooseMode } from "./fixtures/equalities-in-loose-mode.js";
 
-it.each([
-  ...comparisonsInLooseMode,
-  ...equalitiesInLooseMode
-])("should throw an error if $a and $b are compared in strict mode", ({ a, b }) => {
-  expect(() => compare(a, b)).toThrow();
-});
+it.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+  "should throw an error if $a and $b are compared in strict mode",
+  ({ a, b }) => {
+    expect(() => compare(a, b)).toThrow();
+  }
+);
 test.each(comparisons)("$a should be greater than $b", ({ a, b }) => {
   expect(compare(a, b)).toBe(1);
   expect(compare(b, a)).toBe(-1);

--- a/packages/semver/test/diff.test.ts
+++ b/packages/semver/test/diff.test.ts
@@ -7,16 +7,18 @@ import { differencesInLooseMode } from "./fixtures/differences-in-loose-mode.js"
 it("should throw an error if there is an invalid version", () => {
   expect(() => diff("bad", "1.2.3")).toThrow();
 });
-it.each(
-  differencesInLooseMode
-)("should throw an error if $0 and $1 are compared in strict mode", (a, b) => {
-  expect(() => diff(a, b)).toThrow();
-});
+it.each(differencesInLooseMode)(
+  "should throw an error if $0 and $1 are compared in strict mode",
+  (a, b) => {
+    expect(() => diff(a, b)).toThrow();
+  }
+);
 it.each(differences)("should return $2 when $0 and $1 are compared", (a, b, expected) => {
   expect(diff(a, b)).toBe(expected);
 });
-it.each(
-  differencesInLooseMode
-)("should return $2 when $0 and $1 are compared in loose mode", (a, b, expected) => {
-  expect(diff(a, b, { loose: true })).toBe(expected);
-});
+it.each(differencesInLooseMode)(
+  "should return $2 when $0 and $1 are compared in loose mode",
+  (a, b, expected) => {
+    expect(diff(a, b, { loose: true })).toBe(expected);
+  }
+);

--- a/packages/semver/test/eq.test.ts
+++ b/packages/semver/test/eq.test.ts
@@ -6,12 +6,12 @@ import { comparisonsInLooseMode } from "./fixtures/comparisons-in-loose-mode.js"
 import { equalities } from "./fixtures/equalities.js";
 import { equalitiesInLooseMode } from "./fixtures/equalities-in-loose-mode.js";
 
-it.each([
-  ...comparisonsInLooseMode,
-  ...equalitiesInLooseMode
-])("should throw an error if $a and $b are compared in strict mode", ({ a, b }) => {
-  expect(() => eq(a, b)).toThrow();
-});
+it.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+  "should throw an error if $a and $b are compared in strict mode",
+  ({ a, b }) => {
+    expect(() => eq(a, b)).toThrow();
+  }
+);
 test.each(equalities)("$a should be equal to $b", ({ a, b }) => {
   expect(eq(a, b)).toBe(true);
 });

--- a/packages/semver/test/get-difference.test.ts
+++ b/packages/semver/test/get-difference.test.ts
@@ -7,16 +7,18 @@ import { differencesInLooseMode } from "./fixtures/differences-in-loose-mode.js"
 it("should throw an error if there is an invalid version", () => {
   expect(() => getDifference("bad", "1.2.3")).toThrow();
 });
-it.each(
-  differencesInLooseMode
-)("should throw an error if $0 and $1 are compared in strict mode", (a, b) => {
-  expect(() => getDifference(a, b)).toThrow();
-});
+it.each(differencesInLooseMode)(
+  "should throw an error if $0 and $1 are compared in strict mode",
+  (a, b) => {
+    expect(() => getDifference(a, b)).toThrow();
+  }
+);
 it.each(differences)("should return $2 when $0 and $1 are compared", (a, b, expected) => {
   expect(getDifference(a, b)).toBe(expected);
 });
-it.each(
-  differencesInLooseMode
-)("should return $2 when $0 and $1 are compared in loose mode", (a, b, expected) => {
-  expect(getDifference(a, b, { loose: true })).toBe(expected);
-});
+it.each(differencesInLooseMode)(
+  "should return $2 when $0 and $1 are compared in loose mode",
+  (a, b, expected) => {
+    expect(getDifference(a, b, { loose: true })).toBe(expected);
+  }
+);

--- a/packages/semver/test/get-max-satisfying-version.test.ts
+++ b/packages/semver/test/get-max-satisfying-version.test.ts
@@ -7,21 +7,15 @@ import { maxSatisfyingVersionsInLooseMode } from "./fixtures/max-satisfying-vers
 it("should return `null` if there are bad ranges", () => {
   expect(getMaxSatisfyingVersion([], "some frogs-v2.5.6")).toBe(null);
 });
-it.each(
-  maxSatisfyingVersionsInLooseMode
-)("should return $expected when $versions are checked against $range in loose mode", ({
-  versions,
-  range,
-  expected
-}) => {
-  expect(getMaxSatisfyingVersion(versions, range, { loose: true })).toBe(expected);
-});
-it.each(
-  maxSatisfyingVersions
-)("should return $expected when $versions are checked against $range", ({
-  versions,
-  range,
-  expected
-}) => {
-  expect(getMaxSatisfyingVersion(versions, range)).toBe(expected);
-});
+it.each(maxSatisfyingVersionsInLooseMode)(
+  "should return $expected when $versions are checked against $range in loose mode",
+  ({ versions, range, expected }) => {
+    expect(getMaxSatisfyingVersion(versions, range, { loose: true })).toBe(expected);
+  }
+);
+it.each(maxSatisfyingVersions)(
+  "should return $expected when $versions are checked against $range",
+  ({ versions, range, expected }) => {
+    expect(getMaxSatisfyingVersion(versions, range)).toBe(expected);
+  }
+);

--- a/packages/semver/test/get-min-satisfying-version.test.ts
+++ b/packages/semver/test/get-min-satisfying-version.test.ts
@@ -7,21 +7,15 @@ import { minSatisfyingVersionsInLooseMode } from "./fixtures/min-satisfying-vers
 it("should return `null` if there are bad ranges", () => {
   expect(getMinSatisfyingVersion([], "some frogs-v2.5.6")).toBe(null);
 });
-it.each(
-  minSatisfyingVersionsInLooseMode
-)("should return $expected when $versions are checked against $range in loose mode", ({
-  versions,
-  range,
-  expected
-}) => {
-  expect(getMinSatisfyingVersion(versions, range, { loose: true })).toBe(expected);
-});
-it.each(
-  minSatisfyingVersions
-)("should return $expected when $versions are checked against $range", ({
-  versions,
-  range,
-  expected
-}) => {
-  expect(getMinSatisfyingVersion(versions, range)).toBe(expected);
-});
+it.each(minSatisfyingVersionsInLooseMode)(
+  "should return $expected when $versions are checked against $range in loose mode",
+  ({ versions, range, expected }) => {
+    expect(getMinSatisfyingVersion(versions, range, { loose: true })).toBe(expected);
+  }
+);
+it.each(minSatisfyingVersions)(
+  "should return $expected when $versions are checked against $range",
+  ({ versions, range, expected }) => {
+    expect(getMinSatisfyingVersion(versions, range)).toBe(expected);
+  }
+);

--- a/packages/semver/test/get-prerelease.test.ts
+++ b/packages/semver/test/get-prerelease.test.ts
@@ -12,22 +12,21 @@ it.each(invalidVersionsForPrerelease)("should return `null` if %s is invalid", r
 it.each(versionsWithoutPrerelease)("should return `null` if %s is parsed", raw => {
   expect(getPrerelease(raw)).toBe(null);
 });
-it.each(
-  versionsWithPrereleaseInLooseMode
-)("should return `null` if $raw is parsed in strict mode", ({ raw }) => {
-  expect(getPrerelease(raw)).toBe(null);
-});
-it.each(
-  versionsWithPrereleaseInLooseMode
-)("should return the prerelease components if $raw is parsed in loose mode", ({
-  raw,
-  prerelease
-}) => {
-  assert.deepEqual(getPrerelease(raw, { loose: true }), prerelease);
-});
-it.each(versionsWithPrerelease)("should return the prerelease components if $raw is parsed", ({
-  raw,
-  prerelease
-}) => {
-  assert.deepEqual(getPrerelease(raw), prerelease);
-});
+it.each(versionsWithPrereleaseInLooseMode)(
+  "should return `null` if $raw is parsed in strict mode",
+  ({ raw }) => {
+    expect(getPrerelease(raw)).toBe(null);
+  }
+);
+it.each(versionsWithPrereleaseInLooseMode)(
+  "should return the prerelease components if $raw is parsed in loose mode",
+  ({ raw, prerelease }) => {
+    assert.deepEqual(getPrerelease(raw, { loose: true }), prerelease);
+  }
+);
+it.each(versionsWithPrerelease)(
+  "should return the prerelease components if $raw is parsed",
+  ({ raw, prerelease }) => {
+    assert.deepEqual(getPrerelease(raw), prerelease);
+  }
+);

--- a/packages/semver/test/gt-range.test.ts
+++ b/packages/semver/test/gt-range.test.ts
@@ -4,13 +4,15 @@ import { gtRange } from "../src/index.js";
 import { versionsGtRange } from "./fixtures/versions-gt-range.js";
 import { versionsNotGtRange } from "./fixtures/versions-not-gt-range.js";
 
-it.each(
-  versionsGtRange
-)("should return `true` with version $1 and range $0", (range, version, options) => {
-  expect(gtRange(version, range, options)).toBe(true);
-});
-it.each(
-  versionsNotGtRange
-)("should return `false` with version $1 and range $0", (range, version, options) => {
-  expect(gtRange(version, range, options)).toBe(false);
-});
+it.each(versionsGtRange)(
+  "should return `true` with version $1 and range $0",
+  (range, version, options) => {
+    expect(gtRange(version, range, options)).toBe(true);
+  }
+);
+it.each(versionsNotGtRange)(
+  "should return `false` with version $1 and range $0",
+  (range, version, options) => {
+    expect(gtRange(version, range, options)).toBe(false);
+  }
+);

--- a/packages/semver/test/gt.test.ts
+++ b/packages/semver/test/gt.test.ts
@@ -4,12 +4,12 @@ import { gt } from "../src/index.js";
 import { comparisons } from "./fixtures/comparisons.js";
 import { comparisonsInLooseMode } from "./fixtures/comparisons-in-loose-mode.js";
 
-it.each(comparisonsInLooseMode)("should throw an error if $a and $b are compared in strict mode", ({
-  a,
-  b
-}) => {
-  expect(() => gt(a, b)).toThrow();
-});
+it.each(comparisonsInLooseMode)(
+  "should throw an error if $a and $b are compared in strict mode",
+  ({ a, b }) => {
+    expect(() => gt(a, b)).toThrow();
+  }
+);
 test.each(comparisons)("$a should be greater than $b", ({ a, b }) => {
   expect(gt(a, b)).toBe(true);
 });

--- a/packages/semver/test/gte.test.ts
+++ b/packages/semver/test/gte.test.ts
@@ -6,30 +6,30 @@ import { comparisonsInLooseMode } from "./fixtures/comparisons-in-loose-mode.js"
 import { equalities } from "./fixtures/equalities.js";
 import { equalitiesInLooseMode } from "./fixtures/equalities-in-loose-mode.js";
 
-it.each([
-  ...comparisonsInLooseMode,
-  ...equalitiesInLooseMode
-])("should throw an error if $a and $b are compared in strict mode", ({ a, b }) => {
-  expect(() => gte(a, b)).toThrow();
-});
-test.each([...comparisons, ...equalities])("$a should be greater than or equal to $b", ({
-  a,
-  b
-}) => {
-  expect(gte(a, b)).toBe(true);
-});
-test.each([
-  ...comparisonsInLooseMode,
-  ...equalitiesInLooseMode
-])("$a should be greater than or equal to $b in loose mode", ({ a, b }) => {
-  expect(gte(a, b, { loose: true })).toBe(true);
-});
+it.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+  "should throw an error if $a and $b are compared in strict mode",
+  ({ a, b }) => {
+    expect(() => gte(a, b)).toThrow();
+  }
+);
+test.each([...comparisons, ...equalities])(
+  "$a should be greater than or equal to $b",
+  ({ a, b }) => {
+    expect(gte(a, b)).toBe(true);
+  }
+);
+test.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+  "$a should be greater than or equal to $b in loose mode",
+  ({ a, b }) => {
+    expect(gte(a, b, { loose: true })).toBe(true);
+  }
+);
 test.each(comparisons)("$a should not be greater than or equal to $b", ({ a, b }) => {
   expect(gte(b, a)).toBe(false);
 });
-test.each(comparisonsInLooseMode)("$a should not be greater than or equal to $b in loose mode", ({
-  a,
-  b
-}) => {
-  expect(gte(b, a, { loose: true })).toBe(false);
-});
+test.each(comparisonsInLooseMode)(
+  "$a should not be greater than or equal to $b in loose mode",
+  ({ a, b }) => {
+    expect(gte(b, a, { loose: true })).toBe(false);
+  }
+);

--- a/packages/semver/test/gtr.test.ts
+++ b/packages/semver/test/gtr.test.ts
@@ -4,13 +4,15 @@ import { gtr } from "../src/index.js";
 import { versionsGtRange } from "./fixtures/versions-gt-range.js";
 import { versionsNotGtRange } from "./fixtures/versions-not-gt-range.js";
 
-it.each(
-  versionsGtRange
-)("should return `true` with version $1 and range $0", (range, version, options) => {
-  expect(gtr(version, range, options)).toBe(true);
-});
-it.each(
-  versionsNotGtRange
-)("should return `false` with version $1 and range $0", (range, version, options) => {
-  expect(gtr(version, range, options)).toBe(false);
-});
+it.each(versionsGtRange)(
+  "should return `true` with version $1 and range $0",
+  (range, version, options) => {
+    expect(gtr(version, range, options)).toBe(true);
+  }
+);
+it.each(versionsNotGtRange)(
+  "should return `false` with version $1 and range $0",
+  (range, version, options) => {
+    expect(gtr(version, range, options)).toBe(false);
+  }
+);

--- a/packages/semver/test/inc.test.ts
+++ b/packages/semver/test/inc.test.ts
@@ -4,23 +4,17 @@ import { inc } from "../src/inc.js";
 import { validIncrements } from "./fixtures/valid-increments.js";
 import { validIncrementsInLooseMode } from "./fixtures/valid-increments-in-loose-mode.js";
 
-it.each(
-  validIncrementsInLooseMode
-)("should return $expected.version when it is $version in loose mode ($releaseType)", ({
-  version,
-  releaseType,
-  expected,
-  prefix,
-  identifierBase
-}) => {
-  expect(inc(version, releaseType, { loose: true }, prefix, identifierBase)).toBe(expected.version);
-});
-it.each(validIncrements)("should return $expected.version when it is $version ($releaseType)", ({
-  version,
-  releaseType,
-  expected,
-  prefix,
-  identifierBase
-}) => {
-  expect(inc(version, releaseType, prefix, identifierBase)).toBe(expected.version);
-});
+it.each(validIncrementsInLooseMode)(
+  "should return $expected.version when it is $version in loose mode ($releaseType)",
+  ({ version, releaseType, expected, prefix, identifierBase }) => {
+    expect(inc(version, releaseType, { loose: true }, prefix, identifierBase)).toBe(
+      expected.version
+    );
+  }
+);
+it.each(validIncrements)(
+  "should return $expected.version when it is $version ($releaseType)",
+  ({ version, releaseType, expected, prefix, identifierBase }) => {
+    expect(inc(version, releaseType, prefix, identifierBase)).toBe(expected.version);
+  }
+);

--- a/packages/semver/test/increase.test.ts
+++ b/packages/semver/test/increase.test.ts
@@ -5,45 +5,29 @@ import { invalidIncrements } from "./fixtures/invalid-increments.js";
 import { validIncrements } from "./fixtures/valid-increments.js";
 import { validIncrementsInLooseMode } from "./fixtures/valid-increments-in-loose-mode.js";
 
-it.each(
-  invalidIncrements
-)("should return `null` if the version $version is invalid to be increased", ({
-  version,
-  releaseType,
-  prefix,
-  identifierBase
-}) => {
-  expect(increase(version, releaseType, { prefix, identifierBase })).toBe(null);
-});
-it.each(
-  validIncrementsInLooseMode
-)("should throw an error if the version $version is invalid to be increased in strict mode", ({
-  version,
-  releaseType,
-  prefix,
-  identifierBase
-}) => {
-  expect(increase(version, releaseType, { prefix, identifierBase })).toBe(null);
-});
-it.each(validIncrements)("should return $expected.version when it is $version ($releaseType)", ({
-  version,
-  releaseType,
-  expected,
-  prefix,
-  identifierBase
-}) => {
-  expect(increase(version, releaseType, { prefix, identifierBase })).toBe(expected.version);
-});
-it.each(
-  validIncrementsInLooseMode
-)("should return $expected.version when it is $version in loose mode ($releaseType)", ({
-  version,
-  releaseType,
-  expected,
-  prefix,
-  identifierBase
-}) => {
-  expect(increase(version, releaseType, { prefix, identifierBase }, { loose: true })).toBe(
-    expected.version
-  );
-});
+it.each(invalidIncrements)(
+  "should return `null` if the version $version is invalid to be increased",
+  ({ version, releaseType, prefix, identifierBase }) => {
+    expect(increase(version, releaseType, { prefix, identifierBase })).toBe(null);
+  }
+);
+it.each(validIncrementsInLooseMode)(
+  "should throw an error if the version $version is invalid to be increased in strict mode",
+  ({ version, releaseType, prefix, identifierBase }) => {
+    expect(increase(version, releaseType, { prefix, identifierBase })).toBe(null);
+  }
+);
+it.each(validIncrements)(
+  "should return $expected.version when it is $version ($releaseType)",
+  ({ version, releaseType, expected, prefix, identifierBase }) => {
+    expect(increase(version, releaseType, { prefix, identifierBase })).toBe(expected.version);
+  }
+);
+it.each(validIncrementsInLooseMode)(
+  "should return $expected.version when it is $version in loose mode ($releaseType)",
+  ({ version, releaseType, expected, prefix, identifierBase }) => {
+    expect(increase(version, releaseType, { prefix, identifierBase }, { loose: true })).toBe(
+      expected.version
+    );
+  }
+);

--- a/packages/semver/test/intersects.test.ts
+++ b/packages/semver/test/intersects.test.ts
@@ -5,43 +5,51 @@ import { comparatorIntersections } from "./fixtures/comparator-intersections.js"
 import { comparatorIntersectionsInLooseMode } from "./fixtures/comparator-intersections-in-loose-mode.js";
 import { rangeIntersections } from "./fixtures/range-intersections.js";
 
-it.each(
-  comparatorIntersections
-)("should return `$2` when $0 intersects $1", (range1, range2, expected, options) => {
-  expect(intersects(range1, range2, options)).toBe(expected);
-});
-it.each(
-  comparatorIntersections
-)("should return `$2` when $1 intersects $0", (range1, range2, expected, options) => {
-  expect(intersects(range2, range1, options)).toBe(expected);
-});
-it.each(
-  comparatorIntersectionsInLooseMode
-)("should return `$2` when $0 intersects $1 in loose mode", (range1, range2, expected, options) => {
-  expect(intersects(range1, range2, { ...options, loose: true })).toBe(expected);
-});
-it.each(
-  comparatorIntersectionsInLooseMode
-)("should return `$2` when $1 intersects $0 in loose mode", (range1, range2, expected, options) => {
-  expect(intersects(range2, range1, { ...options, loose: true })).toBe(expected);
-});
-it.each(
-  rangeIntersections
-)("should return `$2` when $0 intersects $1", (range1, range2, expected) => {
-  expect(intersects(range1, range2)).toBe(expected);
-});
-it.each(
-  rangeIntersections
-)("should return `$2` when $1 intersects $0", (range1, range2, expected) => {
-  expect(intersects(range2, range1)).toBe(expected);
-});
-it.each(
-  rangeIntersections
-)("should return `$2` when $0 intersects $1 in loose mode", (range1, range2, expected) => {
-  expect(intersects(range1, range2, { loose: true })).toBe(expected);
-});
-it.each(
-  rangeIntersections
-)("should return `$2` when $1 intersects $0 in loose mode", (range1, range2, expected) => {
-  expect(intersects(range2, range1, { loose: true })).toBe(expected);
-});
+it.each(comparatorIntersections)(
+  "should return `$2` when $0 intersects $1",
+  (range1, range2, expected, options) => {
+    expect(intersects(range1, range2, options)).toBe(expected);
+  }
+);
+it.each(comparatorIntersections)(
+  "should return `$2` when $1 intersects $0",
+  (range1, range2, expected, options) => {
+    expect(intersects(range2, range1, options)).toBe(expected);
+  }
+);
+it.each(comparatorIntersectionsInLooseMode)(
+  "should return `$2` when $0 intersects $1 in loose mode",
+  (range1, range2, expected, options) => {
+    expect(intersects(range1, range2, { ...options, loose: true })).toBe(expected);
+  }
+);
+it.each(comparatorIntersectionsInLooseMode)(
+  "should return `$2` when $1 intersects $0 in loose mode",
+  (range1, range2, expected, options) => {
+    expect(intersects(range2, range1, { ...options, loose: true })).toBe(expected);
+  }
+);
+it.each(rangeIntersections)(
+  "should return `$2` when $0 intersects $1",
+  (range1, range2, expected) => {
+    expect(intersects(range1, range2)).toBe(expected);
+  }
+);
+it.each(rangeIntersections)(
+  "should return `$2` when $1 intersects $0",
+  (range1, range2, expected) => {
+    expect(intersects(range2, range1)).toBe(expected);
+  }
+);
+it.each(rangeIntersections)(
+  "should return `$2` when $0 intersects $1 in loose mode",
+  (range1, range2, expected) => {
+    expect(intersects(range1, range2, { loose: true })).toBe(expected);
+  }
+);
+it.each(rangeIntersections)(
+  "should return `$2` when $1 intersects $0 in loose mode",
+  (range1, range2, expected) => {
+    expect(intersects(range2, range1, { loose: true })).toBe(expected);
+  }
+);

--- a/packages/semver/test/is-range-subset.test.ts
+++ b/packages/semver/test/is-range-subset.test.ts
@@ -7,8 +7,9 @@ it("should return `true` if the subrange is a subset of itself", () => {
   const mockedRange = "^1";
   expect(isRangeSubset(mockedRange, mockedRange)).toBe(true);
 });
-it.each(
-  rangeSubsets
-)("should return $2 when subset $0 is compared to range $1", (subRange, superRange, expected, options) => {
-  expect(isRangeSubset(subRange, superRange, options)).toBe(expected);
-});
+it.each(rangeSubsets)(
+  "should return $2 when subset $0 is compared to range $1",
+  (subRange, superRange, expected, options) => {
+    expect(isRangeSubset(subRange, superRange, options)).toBe(expected);
+  }
+);

--- a/packages/semver/test/is-version-outside.test.ts
+++ b/packages/semver/test/is-version-outside.test.ts
@@ -6,23 +6,27 @@ import { versionsLtRange } from "./fixtures/versions-lt-range.js";
 import { versionsNotGtRange } from "./fixtures/versions-not-gt-range.js";
 import { versionsNotLtRange } from "./fixtures/versions-not-lt-range.js";
 
-it.each(
-  versionsGtRange
-)("should return `true` with operator '>', version $1 and range $0", (range, version, options) => {
-  expect(isVersionOutside(version, range, ">", options)).toBe(true);
-});
-it.each(
-  versionsLtRange
-)("should return `true` with operator '<', version $1 and range $0", (range, version, options) => {
-  expect(isVersionOutside(version, range, "<", options)).toBe(true);
-});
-it.each(
-  versionsNotGtRange
-)("should return `false` with operator '>', version $1 and range $0", (range, version, options) => {
-  expect(isVersionOutside(version, range, ">", options)).toBe(false);
-});
-it.each(
-  versionsNotLtRange
-)("should return `false` with operator '<', version $1 and range $0", (range, version, options) => {
-  expect(isVersionOutside(version, range, "<", options)).toBe(false);
-});
+it.each(versionsGtRange)(
+  "should return `true` with operator '>', version $1 and range $0",
+  (range, version, options) => {
+    expect(isVersionOutside(version, range, ">", options)).toBe(true);
+  }
+);
+it.each(versionsLtRange)(
+  "should return `true` with operator '<', version $1 and range $0",
+  (range, version, options) => {
+    expect(isVersionOutside(version, range, "<", options)).toBe(true);
+  }
+);
+it.each(versionsNotGtRange)(
+  "should return `false` with operator '>', version $1 and range $0",
+  (range, version, options) => {
+    expect(isVersionOutside(version, range, ">", options)).toBe(false);
+  }
+);
+it.each(versionsNotLtRange)(
+  "should return `false` with operator '<', version $1 and range $0",
+  (range, version, options) => {
+    expect(isVersionOutside(version, range, "<", options)).toBe(false);
+  }
+);

--- a/packages/semver/test/lt-range.test.ts
+++ b/packages/semver/test/lt-range.test.ts
@@ -4,13 +4,15 @@ import { ltRange } from "../src/index.js";
 import { versionsLtRange } from "./fixtures/versions-lt-range.js";
 import { versionsNotLtRange } from "./fixtures/versions-not-lt-range.js";
 
-it.each(
-  versionsLtRange
-)("should return `true` with version $1 and range $0", (range, version, options) => {
-  expect(ltRange(version, range, options)).toBe(true);
-});
-it.each(
-  versionsNotLtRange
-)("should return `false` with version $1 and range $0", (range, version, options) => {
-  expect(ltRange(version, range, options)).toBe(false);
-});
+it.each(versionsLtRange)(
+  "should return `true` with version $1 and range $0",
+  (range, version, options) => {
+    expect(ltRange(version, range, options)).toBe(true);
+  }
+);
+it.each(versionsNotLtRange)(
+  "should return `false` with version $1 and range $0",
+  (range, version, options) => {
+    expect(ltRange(version, range, options)).toBe(false);
+  }
+);

--- a/packages/semver/test/lt.test.ts
+++ b/packages/semver/test/lt.test.ts
@@ -4,12 +4,12 @@ import { lt } from "../src/index.js";
 import { comparisons } from "./fixtures/comparisons.js";
 import { comparisonsInLooseMode } from "./fixtures/comparisons-in-loose-mode.js";
 
-it.each(comparisonsInLooseMode)("should throw an error if $a and $b are compared in strict mode", ({
-  a,
-  b
-}) => {
-  expect(() => lt(a, b)).toThrow();
-});
+it.each(comparisonsInLooseMode)(
+  "should throw an error if $a and $b are compared in strict mode",
+  ({ a, b }) => {
+    expect(() => lt(a, b)).toThrow();
+  }
+);
 test.each(comparisons)("$a should be less than $b", ({ a, b }) => {
   expect(lt(b, a)).toBe(true);
 });

--- a/packages/semver/test/lte.test.ts
+++ b/packages/semver/test/lte.test.ts
@@ -6,27 +6,27 @@ import { comparisonsInLooseMode } from "./fixtures/comparisons-in-loose-mode.js"
 import { equalities } from "./fixtures/equalities.js";
 import { equalitiesInLooseMode } from "./fixtures/equalities-in-loose-mode.js";
 
-it.each([
-  ...comparisonsInLooseMode,
-  ...equalitiesInLooseMode
-])("should throw an error if $a and $b are compared in strict mode", ({ a, b }) => {
-  expect(() => lte(a, b)).toThrow();
-});
+it.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+  "should throw an error if $a and $b are compared in strict mode",
+  ({ a, b }) => {
+    expect(() => lte(a, b)).toThrow();
+  }
+);
 test.each([...comparisons, ...equalities])("$a should be less than or equal to $b", ({ a, b }) => {
   expect(lte(b, a)).toBe(true);
 });
-test.each([
-  ...comparisonsInLooseMode,
-  ...equalitiesInLooseMode
-])("$a should be less than or equal to $b in loose mode", ({ a, b }) => {
-  expect(lte(b, a, { loose: true })).toBe(true);
-});
+test.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+  "$a should be less than or equal to $b in loose mode",
+  ({ a, b }) => {
+    expect(lte(b, a, { loose: true })).toBe(true);
+  }
+);
 test.each(comparisons)("$a should not be less than or equal to $b", ({ a, b }) => {
   expect(lte(a, b)).toBe(false);
 });
-test.each(comparisonsInLooseMode)("$a should not be less than or equal to $b in loose mode", ({
-  a,
-  b
-}) => {
-  expect(lte(a, b, { loose: true })).toBe(false);
-});
+test.each(comparisonsInLooseMode)(
+  "$a should not be less than or equal to $b in loose mode",
+  ({ a, b }) => {
+    expect(lte(a, b, { loose: true })).toBe(false);
+  }
+);

--- a/packages/semver/test/ltr.test.ts
+++ b/packages/semver/test/ltr.test.ts
@@ -4,13 +4,15 @@ import { ltr } from "../src/index.js";
 import { versionsLtRange } from "./fixtures/versions-lt-range.js";
 import { versionsNotLtRange } from "./fixtures/versions-not-lt-range.js";
 
-it.each(
-  versionsLtRange
-)("should return `true` with version $1 and range $0", (range, version, options) => {
-  expect(ltr(version, range, options)).toBe(true);
-});
-it.each(
-  versionsNotLtRange
-)("should return `false` with version $1 and range $0", (range, version, options) => {
-  expect(ltr(version, range, options)).toBe(false);
-});
+it.each(versionsLtRange)(
+  "should return `true` with version $1 and range $0",
+  (range, version, options) => {
+    expect(ltr(version, range, options)).toBe(true);
+  }
+);
+it.each(versionsNotLtRange)(
+  "should return `false` with version $1 and range $0",
+  (range, version, options) => {
+    expect(ltr(version, range, options)).toBe(false);
+  }
+);

--- a/packages/semver/test/max-satisfying.test.ts
+++ b/packages/semver/test/max-satisfying.test.ts
@@ -7,21 +7,15 @@ import { maxSatisfyingVersionsInLooseMode } from "./fixtures/max-satisfying-vers
 it("should return `null` if there are bad ranges", () => {
   expect(maxSatisfying([], "some frogs-v2.5.6")).toBe(null);
 });
-it.each(
-  maxSatisfyingVersionsInLooseMode
-)("should return $expected when $versions are checked against $range in loose mode", ({
-  versions,
-  range,
-  expected
-}) => {
-  expect(maxSatisfying(versions, range, { loose: true })).toBe(expected);
-});
-it.each(
-  maxSatisfyingVersions
-)("should return $expected when $versions are checked against $range", ({
-  versions,
-  range,
-  expected
-}) => {
-  expect(maxSatisfying(versions, range)).toBe(expected);
-});
+it.each(maxSatisfyingVersionsInLooseMode)(
+  "should return $expected when $versions are checked against $range in loose mode",
+  ({ versions, range, expected }) => {
+    expect(maxSatisfying(versions, range, { loose: true })).toBe(expected);
+  }
+);
+it.each(maxSatisfyingVersions)(
+  "should return $expected when $versions are checked against $range",
+  ({ versions, range, expected }) => {
+    expect(maxSatisfying(versions, range)).toBe(expected);
+  }
+);

--- a/packages/semver/test/min-satisfying.test.ts
+++ b/packages/semver/test/min-satisfying.test.ts
@@ -7,21 +7,15 @@ import { minSatisfyingVersionsInLooseMode } from "./fixtures/min-satisfying-vers
 it("should return `null` if there are bad ranges", () => {
   expect(minSatisfying([], "some frogs-v2.5.6")).toBe(null);
 });
-it.each(
-  minSatisfyingVersionsInLooseMode
-)("should return $expected when $versions are checked against $range in loose mode", ({
-  versions,
-  range,
-  expected
-}) => {
-  expect(minSatisfying(versions, range, { loose: true })).toBe(expected);
-});
-it.each(
-  minSatisfyingVersions
-)("should return $expected when $versions are checked against $range", ({
-  versions,
-  range,
-  expected
-}) => {
-  expect(minSatisfying(versions, range)).toBe(expected);
-});
+it.each(minSatisfyingVersionsInLooseMode)(
+  "should return $expected when $versions are checked against $range in loose mode",
+  ({ versions, range, expected }) => {
+    expect(minSatisfying(versions, range, { loose: true })).toBe(expected);
+  }
+);
+it.each(minSatisfyingVersions)(
+  "should return $expected when $versions are checked against $range",
+  ({ versions, range, expected }) => {
+    expect(minSatisfying(versions, range)).toBe(expected);
+  }
+);

--- a/packages/semver/test/neq.test.ts
+++ b/packages/semver/test/neq.test.ts
@@ -6,12 +6,12 @@ import { comparisonsInLooseMode } from "./fixtures/comparisons-in-loose-mode.js"
 import { equalities } from "./fixtures/equalities.js";
 import { equalitiesInLooseMode } from "./fixtures/equalities-in-loose-mode.js";
 
-it.each([
-  ...comparisonsInLooseMode,
-  ...equalitiesInLooseMode
-])("should throw an error if $a and $b are compared in strict mode", ({ a, b }) => {
-  expect(() => neq(a, b)).toThrow();
-});
+it.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+  "should throw an error if $a and $b are compared in strict mode",
+  ({ a, b }) => {
+    expect(() => neq(a, b)).toThrow();
+  }
+);
 test.each(comparisons)("$a should not be equal to $b", ({ a, b }) => {
   expect(neq(a, b)).toBe(true);
 });

--- a/packages/semver/test/outside.test.ts
+++ b/packages/semver/test/outside.test.ts
@@ -6,23 +6,27 @@ import { versionsLtRange } from "./fixtures/versions-lt-range.js";
 import { versionsNotGtRange } from "./fixtures/versions-not-gt-range.js";
 import { versionsNotLtRange } from "./fixtures/versions-not-lt-range.js";
 
-it.each(
-  versionsGtRange
-)("should return `true` with operator '>', version $1 and range $0", (range, version, options) => {
-  expect(outside(version, range, ">", options)).toBe(true);
-});
-it.each(
-  versionsLtRange
-)("should return `true` with operator '<', version $1 and range $0", (range, version, options) => {
-  expect(outside(version, range, "<", options)).toBe(true);
-});
-it.each(
-  versionsNotGtRange
-)("should return `false` with operator '>', version $1 and range $0", (range, version, options) => {
-  expect(outside(version, range, ">", options)).toBe(false);
-});
-it.each(
-  versionsNotLtRange
-)("should return `false` with operator '<', version $1 and range $0", (range, version, options) => {
-  expect(outside(version, range, "<", options)).toBe(false);
-});
+it.each(versionsGtRange)(
+  "should return `true` with operator '>', version $1 and range $0",
+  (range, version, options) => {
+    expect(outside(version, range, ">", options)).toBe(true);
+  }
+);
+it.each(versionsLtRange)(
+  "should return `true` with operator '<', version $1 and range $0",
+  (range, version, options) => {
+    expect(outside(version, range, "<", options)).toBe(true);
+  }
+);
+it.each(versionsNotGtRange)(
+  "should return `false` with operator '>', version $1 and range $0",
+  (range, version, options) => {
+    expect(outside(version, range, ">", options)).toBe(false);
+  }
+);
+it.each(versionsNotLtRange)(
+  "should return `false` with operator '<', version $1 and range $0",
+  (range, version, options) => {
+    expect(outside(version, range, "<", options)).toBe(false);
+  }
+);

--- a/packages/semver/test/parse.test.ts
+++ b/packages/semver/test/parse.test.ts
@@ -9,34 +9,35 @@ import { validVersionsInLooseMode } from "./fixtures/valid-versions-in-loose-mod
 it.each(invalidVersions)("should return `null` if $raw is parsed", ({ raw, options }) => {
   expect(parse(raw, options)).toBe(null);
 });
-it.each(validVersionsInLooseMode)("should return `null` if $raw is parsed in strict mode", ({
-  raw
-}) => {
-  expect(parse(raw)).toBe(null);
-});
-it.each(validVersionsInLooseMode)("should return the object if $raw is parsed in loose mode", ({
-  raw,
-  version,
-  expected
-}) => {
-  assert.deepEqual(parse(raw, { loose: true }), { raw, version, ...expected });
-});
-it.each(validVersions)("should return the object if $raw is parsed", ({
-  raw,
-  version,
-  expected
-}) => {
-  assert.deepEqual(parse(raw), { raw, version, ...expected });
-});
-it.each(validVersions)("should return the object as is if $raw is already in an object", ({
-  raw
-}) => {
-  const semver = new Semver(raw);
-  expect(parse(semver)).toBe(semver);
-});
-it.each(
-  validVersionsInLooseMode
-)("should return the object as is if $raw is already in an object (loose mode)", ({ raw }) => {
-  const semver = new Semver(raw, { loose: true });
-  expect(parse(semver)).toBe(semver);
-});
+it.each(validVersionsInLooseMode)(
+  "should return `null` if $raw is parsed in strict mode",
+  ({ raw }) => {
+    expect(parse(raw)).toBe(null);
+  }
+);
+it.each(validVersionsInLooseMode)(
+  "should return the object if $raw is parsed in loose mode",
+  ({ raw, version, expected }) => {
+    assert.deepEqual(parse(raw, { loose: true }), { raw, version, ...expected });
+  }
+);
+it.each(validVersions)(
+  "should return the object if $raw is parsed",
+  ({ raw, version, expected }) => {
+    assert.deepEqual(parse(raw), { raw, version, ...expected });
+  }
+);
+it.each(validVersions)(
+  "should return the object as is if $raw is already in an object",
+  ({ raw }) => {
+    const semver = new Semver(raw);
+    expect(parse(semver)).toBe(semver);
+  }
+);
+it.each(validVersionsInLooseMode)(
+  "should return the object as is if $raw is already in an object (loose mode)",
+  ({ raw }) => {
+    const semver = new Semver(raw, { loose: true });
+    expect(parse(semver)).toBe(semver);
+  }
+);

--- a/packages/semver/test/rcompare.test.ts
+++ b/packages/semver/test/rcompare.test.ts
@@ -6,12 +6,12 @@ import { comparisonsInLooseMode } from "./fixtures/comparisons-in-loose-mode.js"
 import { equalities } from "./fixtures/equalities.js";
 import { equalitiesInLooseMode } from "./fixtures/equalities-in-loose-mode.js";
 
-it.each([
-  ...comparisonsInLooseMode,
-  ...equalitiesInLooseMode
-])("should throw an error if $a and $b are compared in strict mode", ({ a, b }) => {
-  expect(() => rcompare(a, b)).toThrow();
-});
+it.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+  "should throw an error if $a and $b are compared in strict mode",
+  ({ a, b }) => {
+    expect(() => rcompare(a, b)).toThrow();
+  }
+);
 test.each(comparisons)("$a should be less than $b", ({ a, b }) => {
   expect(rcompare(a, b)).toBe(-1);
   expect(rcompare(b, a)).toBe(1);

--- a/packages/semver/test/reverse-compare.test.ts
+++ b/packages/semver/test/reverse-compare.test.ts
@@ -6,12 +6,12 @@ import { comparisonsInLooseMode } from "./fixtures/comparisons-in-loose-mode.js"
 import { equalities } from "./fixtures/equalities.js";
 import { equalitiesInLooseMode } from "./fixtures/equalities-in-loose-mode.js";
 
-it.each([
-  ...comparisonsInLooseMode,
-  ...equalitiesInLooseMode
-])("should throw an error if $a and $b are compared in strict mode", ({ a, b }) => {
-  expect(() => reverseCompare(a, b)).toThrow();
-});
+it.each([...comparisonsInLooseMode, ...equalitiesInLooseMode])(
+  "should throw an error if $a and $b are compared in strict mode",
+  ({ a, b }) => {
+    expect(() => reverseCompare(a, b)).toThrow();
+  }
+);
 test.each(comparisons)("$a should be less than $b", ({ a, b }) => {
   expect(reverseCompare(a, b)).toBe(-1);
   expect(reverseCompare(b, a)).toBe(1);

--- a/packages/semver/test/reverse-sort.test.ts
+++ b/packages/semver/test/reverse-sort.test.ts
@@ -10,9 +10,9 @@ it.each(listsToSortInLooseMode)("should throw an error in strict mode", ({ list 
 it.each(listsToSort)("should sort in ascending order", ({ list, expectedDescending }) => {
   assert.deepEqual(reverseSort(list), expectedDescending);
 });
-it.each(listsToSortInLooseMode)("should sort in ascending order in loose mode", ({
-  list,
-  expectedDescending
-}) => {
-  assert.deepEqual(reverseSort(list, { loose: true }), expectedDescending);
-});
+it.each(listsToSortInLooseMode)(
+  "should sort in ascending order in loose mode",
+  ({ list, expectedDescending }) => {
+    assert.deepEqual(reverseSort(list, { loose: true }), expectedDescending);
+  }
+);

--- a/packages/semver/test/rsort.test.ts
+++ b/packages/semver/test/rsort.test.ts
@@ -10,9 +10,9 @@ it.each(listsToSortInLooseMode)("should throw an error in strict mode", ({ list 
 it.each(listsToSort)("should sort in ascending order", ({ list, expectedDescending }) => {
   assert.deepEqual(rsort(list), expectedDescending);
 });
-it.each(listsToSortInLooseMode)("should sort in ascending order in loose mode", ({
-  list,
-  expectedDescending
-}) => {
-  assert.deepEqual(rsort(list, { loose: true }), expectedDescending);
-});
+it.each(listsToSortInLooseMode)(
+  "should sort in ascending order in loose mode",
+  ({ list, expectedDescending }) => {
+    assert.deepEqual(rsort(list, { loose: true }), expectedDescending);
+  }
+);

--- a/packages/semver/test/sort.test.ts
+++ b/packages/semver/test/sort.test.ts
@@ -10,9 +10,9 @@ it.each(listsToSortInLooseMode)("should throw an error in strict mode", ({ list 
 it.each(listsToSort)("should sort in ascending order", ({ list, expectedAscending }) => {
   assert.deepEqual(sort(list), expectedAscending);
 });
-it.each(listsToSortInLooseMode)("should sort in ascending order in loose mode", ({
-  list,
-  expectedAscending
-}) => {
-  assert.deepEqual(sort(list, { loose: true }), expectedAscending);
-});
+it.each(listsToSortInLooseMode)(
+  "should sort in ascending order in loose mode",
+  ({ list, expectedAscending }) => {
+    assert.deepEqual(sort(list, { loose: true }), expectedAscending);
+  }
+);

--- a/packages/semver/test/subset.test.ts
+++ b/packages/semver/test/subset.test.ts
@@ -7,8 +7,9 @@ it("should return `true` if the subrange is a subset of itself", () => {
   const mockedRange = "^1";
   expect(subset(mockedRange, mockedRange)).toBe(true);
 });
-it.each(
-  rangeSubsets
-)("should return $2 when subset $0 is compared to range $1", (subRange, superRange, expected, options) => {
-  expect(subset(subRange, superRange, options)).toBe(expected);
-});
+it.each(rangeSubsets)(
+  "should return $2 when subset $0 is compared to range $1",
+  (subRange, superRange, expected, options) => {
+    expect(subset(subRange, superRange, options)).toBe(expected);
+  }
+);

--- a/packages/semver/test/valid-range.test.ts
+++ b/packages/semver/test/valid-range.test.ts
@@ -8,22 +8,23 @@ import { validRangesInLooseMode } from "./fixtures/valid-ranges-in-loose-mode.js
 it.each(invalidRanges)("should return `null` if $raw is to be validated", ({ raw, options }) => {
   expect(validRange(raw, options)).toBe(null);
 });
-it.each(validRangesInLooseMode)("should return `null` if $raw is to be validated in strict mode", ({
-  raw
-}) => {
-  expect(validRange(raw)).toBe(null);
-});
-it.each(
-  validRangesInLooseMode
-)("should return $expected.range if $raw is to be validated in loose mode", ({ raw, expected }) => {
-  const { range } = expected;
-  assert.strictEqual(validRange(raw, { loose: true }), range);
-});
-it.each(validRanges)("should return $expected.range if $raw is to be validated", ({
-  raw,
-  expected,
-  options
-}) => {
-  const { range } = expected;
-  assert.strictEqual(validRange(raw, options), range);
-});
+it.each(validRangesInLooseMode)(
+  "should return `null` if $raw is to be validated in strict mode",
+  ({ raw }) => {
+    expect(validRange(raw)).toBe(null);
+  }
+);
+it.each(validRangesInLooseMode)(
+  "should return $expected.range if $raw is to be validated in loose mode",
+  ({ raw, expected }) => {
+    const { range } = expected;
+    assert.strictEqual(validRange(raw, { loose: true }), range);
+  }
+);
+it.each(validRanges)(
+  "should return $expected.range if $raw is to be validated",
+  ({ raw, expected, options }) => {
+    const { range } = expected;
+    assert.strictEqual(validRange(raw, options), range);
+  }
+);

--- a/packages/semver/test/valid.test.ts
+++ b/packages/semver/test/valid.test.ts
@@ -8,16 +8,18 @@ import { validVersionsInLooseMode } from "./fixtures/valid-versions-in-loose-mod
 it.each(invalidVersions)("should return `null` if $raw is to be validated", ({ raw, options }) => {
   expect(valid(raw, options)).toBe(null);
 });
-it.each(
-  validVersionsInLooseMode
-)("should return `null` if $raw is to be validated in strict mode", ({ raw }) => {
-  expect(valid(raw)).toBe(null);
-});
-it.each(
-  validVersionsInLooseMode
-)("should return $version if $raw is to be validated in loose mode", ({ raw, version }) => {
-  assert.strictEqual(valid(raw, { loose: true }), version);
-});
+it.each(validVersionsInLooseMode)(
+  "should return `null` if $raw is to be validated in strict mode",
+  ({ raw }) => {
+    expect(valid(raw)).toBe(null);
+  }
+);
+it.each(validVersionsInLooseMode)(
+  "should return $version if $raw is to be validated in loose mode",
+  ({ raw, version }) => {
+    assert.strictEqual(valid(raw, { loose: true }), version);
+  }
+);
 it.each(validVersions)("should return $raw if $raw is to be validated", ({ raw, version }) => {
   assert.strictEqual(valid(raw), version);
 });

--- a/packages/semver/test/validate-range.test.ts
+++ b/packages/semver/test/validate-range.test.ts
@@ -8,22 +8,23 @@ import { validRangesInLooseMode } from "./fixtures/valid-ranges-in-loose-mode.js
 it.each(invalidRanges)("should return `null` if $raw is to be validated", ({ raw, options }) => {
   expect(validateRange(raw, options)).toBe(null);
 });
-it.each(validRangesInLooseMode)("should return `null` if $raw is to be validated in strict mode", ({
-  raw
-}) => {
-  expect(validateRange(raw)).toBe(null);
-});
-it.each(
-  validRangesInLooseMode
-)("should return $expected.range if $raw is to be validated in loose mode", ({ raw, expected }) => {
-  const { range } = expected;
-  assert.strictEqual(validateRange(raw, { loose: true }), range);
-});
-it.each(validRanges)("should return $expected.range if $raw is to be validated", ({
-  raw,
-  expected,
-  options
-}) => {
-  const { range } = expected;
-  assert.strictEqual(validateRange(raw, options), range);
-});
+it.each(validRangesInLooseMode)(
+  "should return `null` if $raw is to be validated in strict mode",
+  ({ raw }) => {
+    expect(validateRange(raw)).toBe(null);
+  }
+);
+it.each(validRangesInLooseMode)(
+  "should return $expected.range if $raw is to be validated in loose mode",
+  ({ raw, expected }) => {
+    const { range } = expected;
+    assert.strictEqual(validateRange(raw, { loose: true }), range);
+  }
+);
+it.each(validRanges)(
+  "should return $expected.range if $raw is to be validated",
+  ({ raw, expected, options }) => {
+    const { range } = expected;
+    assert.strictEqual(validateRange(raw, options), range);
+  }
+);

--- a/packages/semver/test/validate.test.ts
+++ b/packages/semver/test/validate.test.ts
@@ -8,16 +8,18 @@ import { validVersionsInLooseMode } from "./fixtures/valid-versions-in-loose-mod
 it.each(invalidVersions)("should return `null` if $raw is to be validated", ({ raw, options }) => {
   expect(validate(raw, options)).toBe(null);
 });
-it.each(
-  validVersionsInLooseMode
-)("should return `null` if $raw is to be validated in strict mode", ({ raw }) => {
-  expect(validate(raw)).toBe(null);
-});
-it.each(
-  validVersionsInLooseMode
-)("should return $version if $raw is to be validated in loose mode", ({ raw, version }) => {
-  assert.strictEqual(validate(raw, { loose: true }), version);
-});
+it.each(validVersionsInLooseMode)(
+  "should return `null` if $raw is to be validated in strict mode",
+  ({ raw }) => {
+    expect(validate(raw)).toBe(null);
+  }
+);
+it.each(validVersionsInLooseMode)(
+  "should return $version if $raw is to be validated in loose mode",
+  ({ raw, version }) => {
+    assert.strictEqual(validate(raw, { loose: true }), version);
+  }
+);
 it.each(validVersions)("should return $raw if $raw is to be validated", ({ raw, version }) => {
   assert.strictEqual(validate(raw), version);
 });


### PR DESCRIPTION
Biome 2.5.4 fixes the way arguments of `describe.each` and `it.each` break.
